### PR TITLE
CASMHMS-5205 Reorder HMS CT smoke test execution

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2021-11-29
+
+### Changed
+
+- CASMHMS-5205 - Reordered HMS CT smoke tests to execute HSM tests first
+
 ## [2.0.0] - 2021-11-18
 
 ### Changed

--- a/charts/v2.0/cray-hms-smd/Chart.yaml
+++ b/charts/v2.0/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 2.0.0
+version: 2.0.1
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.34.0"
+appVersion: "1.36.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-smd/values.yaml
+++ b/charts/v2.0/cray-hms-smd/values.yaml
@@ -8,7 +8,7 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.34.0
+  appVersion: 1.36.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -10,6 +10,7 @@ chartVersionToCSMVersion:
 chartVersionToApplicationVersion:
   # Chart version: Application version
   "2.0.0": "1.34.0"
+  "2.0.1": "1.36.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This change updates the HMS CT smoke tests to execute the HSM tests first to more easily and clearly identify discovery-related problems.

### Issues and Related PRs

* Resolves CASMHMS-5205

### Testing

This change was tested by deploying the updated smoke tests and wrapper script to Wasp, executing them, and verifying that the HSM tests ran first. Failures of the HSM smoke tests were also verified to stop execution of the wrapper script as expected.

Was a fresh Install tested? Y
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk.