### PR TITLE
HSM now uses latest hms-msgbus.

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.4] - 2021-12-21
+
+### Changed
+
+- HMS now uses latest hms-msgbus, which replaces Sarama kafka with Confluent.
+
 ## [2.0.3] - 2021-12-07
 
 ### Changed

--- a/charts/v2.0/cray-hms-smd/Chart.yaml
+++ b/charts/v2.0/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 2.0.3
+version: 2.0.4
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.38.0"
+appVersion: "1.39.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-smd/values.yaml
+++ b/charts/v2.0/cray-hms-smd/values.yaml
@@ -8,7 +8,7 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.38.0
+  appVersion: 1.39.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -13,6 +13,7 @@ chartVersionToApplicationVersion:
   "2.0.1": "1.36.0"
   "2.0.2": "1.37.0"
   "2.0.3": "1.38.0"
+  "2.0.4": "1.39.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
HSM now uses latest hms-msgbus, which replaces buggy the Sarama kafka
GO library with the more mature and stable Confluent.

Resolves, in part, CASMHMS-3090.