### PR TITLE
CASMHMS-632 Add HSM component endpoint unit tests

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.6] - 2022-01-11
+
+### Changed
+
+- CASMHMS-632 - Added HSM component endpoint unit tests.
+
 ## [2.0.5] - 2022-01-06
 
 ### Changed

--- a/charts/v2.0/cray-hms-smd/Chart.yaml
+++ b/charts/v2.0/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 2.0.5
+version: 2.0.6
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.40.0"
+appVersion: "1.41.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-smd/values.yaml
+++ b/charts/v2.0/cray-hms-smd/values.yaml
@@ -8,7 +8,7 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.40.0
+  appVersion: 1.41.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -15,6 +15,7 @@ chartVersionToApplicationVersion:
   "2.0.3": "1.38.0"
   "2.0.4": "1.39.0"
   "2.0.5": "1.40.0"
+  "2.0.6": "1.41.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This change adds the following HSM component endpoint unit tests:

- TestDoComponentEndpointGet(), 4 test cases
- TestDoComponentEndpointsGet(), 8 test cases
- TestDoComponentEndpointDelete(), 5 test cases
- TestDoComponentEndpointsDeleteAll(), 5 test cases

### Issues and Related PRs

* Resolves CASMHMS-632.

### Testing

This change was tested by executing the new HSM unit tests locally as well as in the Jenkins build pipeline and verifying that they passed.

Was a fresh Install tested? N
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk.