### PR TITLE
CASMHMS-4974 Add support for HSM /v2/locks/status 'GET' operation for listing all locks

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.7] - 2022-03-04
+
+### Added
+
+- CASMHMS-4974 - Added HSM GET /v2/status/locks API.
+
 ## [2.0.6] - 2022-02-02
 
 ### Fixed

--- a/charts/v2.0/cray-hms-smd/Chart.yaml
+++ b/charts/v2.0/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 2.0.6
+version: 2.0.7
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.43.0"
+appVersion: "1.49.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-smd/values.yaml
+++ b/charts/v2.0/cray-hms-smd/values.yaml
@@ -8,7 +8,7 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.43.0
+  appVersion: 1.49.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -16,6 +16,7 @@ chartVersionToApplicationVersion:
   "2.0.4": "1.39.0"
   "2.0.5": "1.40.0"
   "2.0.6": "1.43.0"
+  "2.0.7": "1.49.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This change adds support for the 'GET' operation to the HSM /v2/locks/status API which will list the lock status of all components in HSM. Optional query parameters may be supplied to filter the results based on component Type, State, Role, SubRole, and Locked, Reserved, ReservationDisabled status. Several corrections to the HSM Swagger specification and a few minor CT test updates are also included.

### Issues and Related PRs

* Resolves CASMHMS-4974.

### Testing

This change was tested by:

- Implementing unit tests for the new /v2/locks/status 'GET' operation
- Spinning up a local instance of HSM in a docker-compose environment, manually populating it with components and setting locks, and executing calls with various query parameters specified
- Upgrading the running HSM service on Mug using Helm to deploy the new version and testing the new functionality using the HSM data from a production environment
- Verifying that the HSM CT smoke and functional tests continued to pass

Was a fresh Install tested? Partially, via a fresh local instance of HSM
Was an Upgrade tested? Y, using Helm
Was a Downgrade tested? Y, using Helm

### Risks and Mitigations

Fairly low risk since this change adds new functionality. Changes that could impact existing HSM /locks/status APIs due to the use of shared functions are minimal and were verified by confirming that their unit tests continued to pass.