### PR TITLE
Change HSM to get node class from SLS

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.9] - 2022-06-03
+
+### Changed
+
+- HSM now uses the 'Class' from SLS
+
 ## [2.0.8] - 2022-05-03
 
 ### Fixed

--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2022-06-03
+
+### Changed
+
+- HSM now uses the 'Class' from SLS
+
 ## [2.1.0] - 2022-05-10
 
 ### Added

--- a/charts/v2.0/cray-hms-smd/Chart.yaml
+++ b/charts/v2.0/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 2.0.8
+version: 2.0.9
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.50.0"
+appVersion: "1.52.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-smd/values.yaml
+++ b/charts/v2.0/cray-hms-smd/values.yaml
@@ -8,7 +8,7 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.50.0
+  appVersion: 1.52.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/charts/v2.1/cray-hms-smd/Chart.yaml
+++ b/charts/v2.1/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 2.1.0
+version: 2.1.1
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.51.0"
+appVersion: "1.52.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-hms-smd/values.yaml
+++ b/charts/v2.1/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.51.0
-  testVersion: 1.51.0
+  appVersion: 1.52.0
+  testVersion: 1.52.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -19,7 +19,9 @@ chartVersionToApplicationVersion:
   "2.0.6": "1.43.0"
   "2.0.7": "1.49.0"
   "2.0.8": "1.50.0"
+  "2.0.9": "1.52.0"
   "2.1.0": "1.51.0"
+  "2.1.1": "1.52.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Updates the HSM image version for CASMTRIAGE-3430

ChassisBMC discovery is complete, it should check that all child components are correctly marked as Mountain components. The filtering for identifying the child components was incorrect. This mod fixes the issue.

This also changes HSM to get class from SLS for node components.

## Issues and Related PRs

* Resolves [CASMTRIAGE-3430](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3430)

## Testing

For testing see https://github.com/Cray-HPE/hms-smd/pull/76

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable