### PR TITLE
Update HSM image version for CASMHMS-4972 and CASMHMS-4973

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.3] - 2022-06-16
+
+### Fixed
+
+- Update HSM to ignore non-GPU components marked as GPUs in proliant iLO redfish
+
 ## [2.1.2] - 2022-06-07
 
 ### Added

--- a/charts/v2.1/cray-hms-smd/Chart.yaml
+++ b/charts/v2.1/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 2.1.2
+version: 2.1.3
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.52.0"
+appVersion: "1.53.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-hms-smd/values.yaml
+++ b/charts/v2.1/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.52.0
-  testVersion: 1.52.0
+  appVersion: 1.53.0
+  testVersion: 1.53.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -23,6 +23,7 @@ chartVersionToApplicationVersion:
   "2.1.0": "1.51.0"
   "2.1.1": "1.52.0"
   "2.1.2": "1.52.0"
+  "2.1.3": "1.53.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

This updates the HSM image version to pick up changes to HSM to ignore switch and baseboard components that are marked as type=GPU when discovering GPUs in proliant iLO devices.

## Issues and Related PRs

* Resolves [CASMHMS-4972](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-4972)
* Resolves [CASMHMS-4973](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-4973)

## Testing

For testing, see https://github.com/Cray-HPE/hms-smd/pull/77

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable