### PR TITLE
Add indexes for hwinv_hist to speed up history event pruning

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.4] - 2022-06-21
+
+### Fixed
+
+- Improve HSM's postgres schema for FRU history pruning.
+
 ## [2.1.3] - 2022-06-16
 
 ### Fixed

--- a/charts/v2.1/cray-hms-smd/Chart.yaml
+++ b/charts/v2.1/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 2.1.3
+version: 2.1.4
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.53.0"
+appVersion: "1.54.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-hms-smd/values.yaml
+++ b/charts/v2.1/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.53.0
-  testVersion: 1.53.0
+  appVersion: 1.54.0
+  testVersion: 1.54.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -24,6 +24,7 @@ chartVersionToApplicationVersion:
   "2.1.1": "1.52.0"
   "2.1.2": "1.52.0"
   "2.1.3": "1.53.0"
+  "2.1.4": "1.54.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Improve HSM's postgres schema for FRU history pruning.

## Issues and Related PRs

* Resolves [CASMHMS-5591](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5591)

## Testing

For testing, see https://github.com/Cray-HPE/hms-smd/pull/78

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable