### PR TITLE
CASMHMS-5458 Coordination for HMS CT Helm tests

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.3] - 2022-06-22
+
+### Changed
+
+- Updated CT tests to hms-test:3.1.0 image as part of Helm test coordination.
+
 ## [2.1.2] - 2022-06-07
 
 ### Added

--- a/charts/v2.1/cray-hms-smd/Chart.yaml
+++ b/charts/v2.1/cray-hms-smd/Chart.yaml
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.52.0"
+appVersion: "1.55.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-hms-smd/Chart.yaml
+++ b/charts/v2.1/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 2.1.2
+version: 2.1.3
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:

--- a/charts/v2.1/cray-hms-smd/values.yaml
+++ b/charts/v2.1/cray-hms-smd/values.yaml
@@ -9,7 +9,8 @@
 
 global:
   appVersion: 1.52.0
-  testVersion: 1.52.0
+  #testVersion: 1.52.0
+  testVersion: 1.52.0-20220613222017.56aad0c
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd
@@ -17,8 +18,9 @@ image:
 
 tests:
   image:
-    repository: artifactory.algol60.net/csm-docker/stable/cray-smd-test
-    pullPolicy: IfNotPresent
+    #repository: artifactory.algol60.net/csm-docker/stable/cray-smd-test
+    repository: artifactory.algol60.net/csm-docker/unstable/cray-smd-test
+    pullPolicy: Always
 
 kubectl:
   image:

--- a/charts/v2.1/cray-hms-smd/values.yaml
+++ b/charts/v2.1/cray-hms-smd/values.yaml
@@ -10,7 +10,7 @@
 global:
   appVersion: 1.52.0
   #testVersion: 1.52.0
-  testVersion: 1.52.0-20220613222017.56aad0c
+  testVersion: 1.52.0-20220613233534.0f2664f
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/charts/v2.1/cray-hms-smd/values.yaml
+++ b/charts/v2.1/cray-hms-smd/values.yaml
@@ -8,9 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.52.0
-  #testVersion: 1.52.0
-  testVersion: 1.52.0-20220615231943.a9a6a48
+  appVersion: 1.55.0
+  testVersion: 1.55.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd
@@ -19,7 +18,7 @@ image:
 tests:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/cray-smd-test
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
 
 kubectl:
   image:

--- a/charts/v2.1/cray-hms-smd/values.yaml
+++ b/charts/v2.1/cray-hms-smd/values.yaml
@@ -10,7 +10,7 @@
 global:
   appVersion: 1.52.0
   #testVersion: 1.52.0
-  testVersion: 1.52.0-20220613233534.0f2664f
+  testVersion: 1.52.0-20220615231943.a9a6a48
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd
@@ -18,8 +18,7 @@ image:
 
 tests:
   image:
-    #repository: artifactory.algol60.net/csm-docker/stable/cray-smd-test
-    repository: artifactory.algol60.net/csm-docker/unstable/cray-smd-test
+    repository: artifactory.algol60.net/csm-docker/stable/cray-smd-test
     pullPolicy: Always
 
 kubectl:

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -23,6 +23,7 @@ chartVersionToApplicationVersion:
   "2.1.0": "1.51.0"
   "2.1.1": "1.52.0"
   "2.1.2": "1.52.0"
+  "2.1.3": "1.55.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This PR includes the following changes:

- Update CT tests to stable hms-test:3.1.0 image (upgrades pytest and tavern to work around python issue43798)
- Pull Alpine base image from correct location in algol60 artifactory
- CT test cleanup

### Issues and Related PRs

* Partially resolves CASMHMS-5458.

### Testing

This change was tested by deploying the updated version of the service and chart onto Mug, executing the Helm CT tests, and verifying that they passed.

Was a fresh Install tested? N
Was an Upgrade tested? Y
Was a Downgrade tested? N

### Risks and Mitigations

Low risk, test update.