### PR TITLE
Fix POST /Inventory/RedfishEndpoints returning 500 instead of 409 for conflicts

### DIFF
--- a/changelog/v3.0.md
+++ b/changelog/v3.0.md
@@ -5,6 +5,13 @@ All notable changes to this project for v3.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2022-07-13
+
+### Fixed
+
+- CASMHMS-5610 - Fixed POST /Inventory/RedfishEndpoints returning 500 instead of 409 for conflicts.
+- CASMHMS-5463 - Fixed smd-init job permissions issues
+
 ## [3.0.0] - 2022-06-29
 
 ### Removed

--- a/charts/v3.0/cray-hms-smd/Chart.yaml
+++ b/charts/v3.0/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 3.0.0
+version: 3.0.1
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.0.0"
+appVersion: "2.1.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v3.0/cray-hms-smd/templates/jobs.yaml
+++ b/charts/v3.0/cray-hms-smd/templates/jobs.yaml
@@ -46,6 +46,9 @@ spec:
         app: cray-smd-init
     spec:
       restartPolicy: OnFailure
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 65534
       serviceAccountName: "jobs-watcher"
       containers:
         - name: cray-smd-init

--- a/charts/v3.0/cray-hms-smd/values.yaml
+++ b/charts/v3.0/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.0.0
-  testVersion: 2.0.0
+  appVersion: 2.1.0
+  testVersion: 2.1.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -28,6 +28,7 @@ chartVersionToApplicationVersion:
   "2.1.4": "1.54.0"
   "2.1.5": "1.55.0"
   "3.0.0": "2.0.0"
+  "3.0.1": "2.1.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

CASMHMS-5610 - Fixed POST /Inventory/RedfishEndpoints returning 500 instead of 409 for conflicts.
CASMHMS-5463 - smd-init job permissions issues

## Issues and Related PRs

* Resolves [CASMHMS-5610](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5610)
* Resolves [CASMHMS-5463](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5463)

## Testing

For testing see https://github.com/Cray-HPE/hms-smd/pull/81

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable