### PR TITLE
Re-add HSM v1 APIs

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,18 @@ All notable changes to this project for v2.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.6] - 2022-07-19
+
+### Removed
+
+- CASMHMS-5625 - Removed much of the redundant v1 API code in preparation for removal in CSM 1.4.
+
+### Fixed
+
+- CASMHMS-5610 - Fixed POST /Inventory/RedfishEndpoints returning 500 instead of 409 for conflicts.
+- CASMHMS-5463 - Fixed smd-init job permissions issues
+- CASMHMS-5373 - Fixed locking bug preventing 'Flexible' requests from working.
+
 ## [2.1.5] - 2022-06-22
 
 ### Changed

--- a/charts/v2.1/cray-hms-smd/Chart.yaml
+++ b/charts/v2.1/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 2.1.5
+version: 2.1.6
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.55.0"
+appVersion: "1.56.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-hms-smd/values.yaml
+++ b/charts/v2.1/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.55.0
-  testVersion: 1.55.0
+  appVersion: 1.56.0
+  testVersion: 1.56.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd
@@ -122,13 +122,13 @@ cray-service:
       livenessProbe:
         httpGet:
           port: 27779
-          path: /hsm/v1/service/liveness
+          path: /hsm/v2/service/liveness
         initialDelaySeconds: 5
         periodSeconds: 10
       readinessProbe:
         httpGet:
           port: 27779
-          path: /hsm/v1/service/ready
+          path: /hsm/v2/service/ready
         initialDelaySeconds: 15
         periodSeconds: 30
         timeoutSeconds: 10

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -4,7 +4,7 @@ chartVersionToCSMVersion:
   # Chart version: CSM version
   ">=2.0.0": "~1.2.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
   ">=2.1.0": "~1.3.0"
-  ">=3.0.0": "~1.3.0"
+  ">=3.0.0": "~1.4.0"
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -27,6 +27,7 @@ chartVersionToApplicationVersion:
   "2.1.3": "1.53.0"
   "2.1.4": "1.54.0"
   "2.1.5": "1.55.0"
+  "2.1.6": "1.56.0"
   "3.0.0": "2.0.0"
   "3.0.1": "2.1.0"
 


### PR DESCRIPTION
## Summary and Scope

HSM v1 API's are temporarily re-added to HSM for CSM 1.3. To be removed for CSM v1.4

## Issues and Related PRs

* Resolves [CASMHMS-5625](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5625)

## Testing

For testing, see https://github.com/Cray-HPE/hms-smd/pull/82

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable