### PR TITLE
CASMHMS-5858 HSM to v1.61.0 for HMTH changes

### DIFF
--- a/changelog/v4.0.md
+++ b/changelog/v4.0.md
@@ -1,9 +1,15 @@
-# Changelog for v2.1
+# Changelog for v4.0
 
-All notable changes to this project for v2.1.Z will be documented in this file.
+All notable changes to this project for v4.0.Z will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [4.0.1] - 2022-12-19
+
+### Changed
+
+- Update HSM CT tests to use hms-test:4.0.0 image for HMTH.
 
 ## [4.0.0] - 2022-09-13
 

--- a/charts/v4.0/cray-hms-smd/Chart.yaml
+++ b/charts/v4.0/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 4.0.0
+version: 4.0.1
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.58.0"
+appVersion: "1.61.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v4.0/cray-hms-smd/templates/tests/test-functional.yaml
+++ b/charts/v4.0/cray-hms-smd/templates/tests/test-functional.yaml
@@ -33,4 +33,4 @@ spec:
           image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
           imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
           command: ["/bin/sh", "-c"]
-          args: [ "entrypoint.sh functional -c /src/libs/tavern_global_config.yaml -p /src/app"]
+          args: ["entrypoint.sh tavern -c /src/libs/tavern_global_config.yaml -p /src/app/api/1-non-disruptive"]

--- a/charts/v4.0/cray-hms-smd/templates/tests/test-smoke.yaml
+++ b/charts/v4.0/cray-hms-smd/templates/tests/test-smoke.yaml
@@ -33,4 +33,4 @@ spec:
           image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
           imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
           command: ["/bin/sh", "-c"]
-          args: [ "entrypoint.sh smoke -f smoke.json -u http://cray-smd"]
+          args: ["entrypoint.sh smoke -f smoke.json -u http://cray-smd"]

--- a/charts/v4.0/cray-hms-smd/values.yaml
+++ b/charts/v4.0/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.58.0
-  testVersion: 1.58.0
+  appVersion: 1.61.0
+  testVersion: 1.61.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd
@@ -17,7 +17,7 @@ image:
 
 tests:
   image:
-    repository: artifactory.algol60.net/csm-docker/stable/cray-smd-test
+    repository: artifactory.algol60.net/csm-docker/stable/cray-smd-hmth-test
     pullPolicy: IfNotPresent
 
 kubectl:

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -36,6 +36,7 @@ chartVersionToApplicationVersion:
   "3.0.1": "2.1.0"
   "3.0.2": "2.1.0"
   "4.0.0": "1.58.0"
+  "4.0.1": "1.61.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This change updates the HSM CT tests to use the latest hms-test:4.0.0 image and RIE for HMTH.

### Issues and Related PRs

* Resolves CASMHMS-5858.

### Testing

This change was tested by deploying the updated HSM Helm chart on Mug, running the CT tests, and verifying that they passed.

Was a fresh Install tested? N
Was an Upgrade tested? Y
Was a Downgrade tested? Y

### Risks and Mitigations

Low risk, pulls in new testing infrastructure for HMTH.