### PR TITLE
Kubernetes api checker casmhms 5842

### DIFF
--- a/.github/workflows/k8s_api_checker.yaml
+++ b/.github/workflows/k8s_api_checker.yaml
@@ -1,0 +1,11 @@
+name: Kubernetes API Checker
+on: [push, pull_request, workflow_dispatch]
+jobs:
+  k8s_api_checker:
+    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/k8s_api_checker.yaml@v2
+    secrets: inherit
+    with:
+      # ignore-errors can be removed once the deprecated APIs are updated.
+      # Setting this to true causes the workflow to always complete as a success
+      # however the reports are still generated.
+      ignore-errors: true


### PR DESCRIPTION
## Summary and Scope

Added the workflow to check for deprecated k8s APIs

The workflow is currently configured to report deprecated APIs, but not to fail,
since the deprecated APIs in this project have not been fixed. These APIs will
be fixed when kubernetes and cert manager are updated in CSM.

## Issues and Related PRs

* Resolves [CASMHMS-5842](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5842)

## Testing

Tested on:

  * various projects with various PRs and branches

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
