### PR TITLE
Fix HSN NIC discovery

### DIFF
--- a/changelog/v4.0.md
+++ b/changelog/v4.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v4.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.2] - 2023-01-09
+
+### Fixed
+
+- CASMTRIAGE-4744 - HSN NIC discovery.
+
 ## [4.0.1] - 2022-12-19
 
 ### Changed

--- a/charts/v4.0/cray-hms-smd/Chart.yaml
+++ b/charts/v4.0/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 4.0.1
+version: 4.0.2
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.61.0"
+appVersion: "1.62.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v4.0/cray-hms-smd/values.yaml
+++ b/charts/v4.0/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.61.0
-  testVersion: 1.61.0
+  appVersion: 1.62.0
+  testVersion: 1.62.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -37,6 +37,7 @@ chartVersionToApplicationVersion:
   "3.0.2": "2.1.0"
   "4.0.0": "1.58.0"
   "4.0.1": "1.61.0"
+  "4.0.2": "1.62.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Update the HSM chart to 1.62.0 for CASMTRIAGE-4744 to fix HSN NIC discovery.

## Issues and Related PRs

* Resolves [CASMTRIAGE-4744](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4744)

## Testing

For testing, see https://github.com/Cray-HPE/hms-smd/pull/94

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable