### PR TITLE
Remove HSM v1 APIs

### DIFF
--- a/changelog/v5.0.md
+++ b/changelog/v5.0.md
@@ -1,0 +1,13 @@
+# Changelog for v5.0
+
+All notable changes to this project for v5.0.Z will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [5.0.0] - 2023-01-09
+
+### Changed
+
+- Remove HSM v1 API

--- a/charts/v5.0/cray-hms-smd/.gitignore
+++ b/charts/v5.0/cray-hms-smd/.gitignore
@@ -1,0 +1,3 @@
+# by default we'll ignore any subcharts included, but simply adjust this if need be
+charts/*
+Chart.lock

--- a/charts/v5.0/cray-hms-smd/Chart.yaml
+++ b/charts/v5.0/cray-hms-smd/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: "cray-hms-smd"
+version: 5.0.0
+description: "Kubernetes resources for cray-hms-smd"
+home: "https://github.com/Cray-HPE/hms-smd-charts"
+sources:
+  - "https://github.com/Cray-HPE/hms-smd"
+dependencies:
+  - name: cray-service
+    version: "~8.2.3"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+maintainers:
+  - name: Hardware Management
+    url: https://github.com/orgs/Cray-HPE/teams/hardware-management
+appVersion: "2.2.0"
+annotations:
+  artifacthub.io/license: "MIT"

--- a/charts/v5.0/cray-hms-smd/templates/NOTES.txt
+++ b/charts/v5.0/cray-hms-smd/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Installation info for chart {{ include "cray-service.name" . }}:

--- a/charts/v5.0/cray-hms-smd/templates/_helpers.tpl
+++ b/charts/v5.0/cray-hms-smd/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{/*
+Add helper methods here for your chart
+*/}}

--- a/charts/v5.0/cray-hms-smd/templates/configmap.yaml
+++ b/charts/v5.0/cray-hms-smd/templates/configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+data:
+  hms_config.json: |-
+    {
+       "HMSExtendedDefinitions":{
+          "Role":[
+             "Compute",
+             "Service",
+             "System",
+             "Application",
+             "Storage",
+             "Management"
+          ],
+          "SubRole":[
+             "Worker",
+             "Master",
+             "Storage",
+             "UAN",
+             "Gateway",
+             "LNETRouter",
+             "Visualization",
+             "UserDefined"
+          ]
+       }
+    }
+kind: ConfigMap
+metadata:
+  name: cray-hms-base-config
+  namespace: services
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: smd-cacert-info
+data:
+  CA_URI: "{{ .Values.hms_ca_uri }}"
+

--- a/charts/v5.0/cray-hms-smd/templates/destinationrules.yaml
+++ b/charts/v5.0/cray-hms-smd/templates/destinationrules.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "cray-hms-smd-shared-kafkarule"
+  labels:
+    app.kubernetes.io/name: cray-hms-smd
+spec:
+  host: "cray-shared-kafka-kafka-bootstrap.services.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "cray-smd-service"
+  labels:
+    app.kubernetes.io/name: cray-hms-smd
+spec:
+  host: "cray-smd"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/charts/v5.0/cray-hms-smd/templates/hook-serviceaccount.yaml
+++ b/charts/v5.0/cray-hms-smd/templates/hook-serviceaccount.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cray-smd-job-deleter
+  namespace: services
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cray-smd-job-deleter
+  namespace: services
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+rules:
+- apiGroups: ["batch", ""]
+  resources: ["jobs", "pods"]
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cray-smd-job-deleter
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cray-smd-job-deleter
+subjects:
+  - kind: ServiceAccount
+    name: cray-smd-job-deleter
+    namespace: services

--- a/charts/v5.0/cray-hms-smd/templates/jobs.yaml
+++ b/charts/v5.0/cray-hms-smd/templates/jobs.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cray-smd-job-deleter
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "0"
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: “false”
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: "cray-smd-job-deleter"
+      containers:
+        - name: job-deleter
+          image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
+          imagePullPolicy: "{{ .Values.kubectl.image.pullPolicy }}"
+          command:
+          - /bin/sh
+          - -c
+          - set -x;
+            echo "Deleting smd-init Job";
+            kubectl -n services delete job cray-smd-init;
+            while [ "`kubectl -n services get pods -l app=cray-smd-init -o jsonpath='{.items}'`" != "[]" ];
+            do
+              echo "Waiting for previous job to be removed entirely...";
+              sleep 1;
+            done;
+            echo "Old job deleted.";
+            exit 0
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cray-smd-init
+  labels:
+    app: cray-smd-init
+spec:
+  template:
+    metadata:
+      labels:
+        app: cray-smd-init
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 65534
+      serviceAccountName: "jobs-watcher"
+      containers:
+        - name: cray-smd-init
+          image: {{ .Values.image.repository }}:{{ .Values.global.appVersion }}
+          env:
+            # NOTE: overridden in container if POSTGRES_HOST is set
+            - name: SMD_DBHOST
+              value: cray-smd-postgres
+            # NOTE: overwritten in container if POSTGRES_PORT is set
+            - name: SMD_DBPORT
+              value: "5432"
+            - name: SMD_DBNAME
+              value: "hmsds"
+            - name: SMD_DBUSER
+              valueFrom:
+                secretKeyRef:
+                  name: hmsdsuser.cray-smd-postgres.credentials
+                  key: username
+            - name: SMD_DBPASS
+              valueFrom:
+                secretKeyRef:
+                  name: hmsdsuser.cray-smd-postgres.credentials
+                  key: password
+            - name: SMD_DBOPTS
+              value: ""
+          volumeMounts:
+            - mountPath: "/persistent_migrations"
+              name: schema
+          command: ["/entrypoint.sh"]
+          args: ["smd-init"]
+      volumes:
+        - name: schema
+          persistentVolumeClaim:
+            claimName: cray-smd-init-pvc

--- a/charts/v5.0/cray-hms-smd/templates/pvc.yaml
+++ b/charts/v5.0/cray-hms-smd/templates/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cray-smd-init-pvc
+spec:
+  accessModes:
+    - "{{ .Values.schemaAccessMode }}"
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: "{{ .Values.schemaStorageClass }}"

--- a/charts/v5.0/cray-hms-smd/templates/tests/test-functional.yaml
+++ b/charts/v5.0/cray-hms-smd/templates/tests/test-functional.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-functional"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "1" #run this after smoke!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-functional"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-functional"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-functional"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "functional"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh tavern -c /src/libs/tavern_global_config.yaml -p /src/app/api/1-non-disruptive"]

--- a/charts/v5.0/cray-hms-smd/templates/tests/test-smoke.yaml
+++ b/charts/v5.0/cray-hms-smd/templates/tests/test-smoke.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-smoke"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1" #run this first!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-smoke"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-smoke"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-smoke"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "smoke"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh smoke -f smoke.json -u http://cray-smd"]

--- a/charts/v5.0/cray-hms-smd/values.yaml
+++ b/charts/v5.0/cray-hms-smd/values.yaml
@@ -1,0 +1,176 @@
+# Please refer to https://github.com/Cray-HPE/cray-charts/tree/master/stable/cray-service/values.yaml?at=refs%2Fheads%2Fmaster
+# for more info on values you can set/override
+# Note that cray-service.containers[*].image and cray-service.initContainers[*].image map values are one of the only structures that
+# differ from the standard kubernetes container spec:
+# image:
+#   repository: ""
+#   tag: "" (default = "latest")
+#   pullPolicy: "" (default = "IfNotPresent")
+
+global:
+  appVersion: 2.2.0
+  testVersion: 2.2.0
+
+image:
+  repository: artifactory.algol60.net/csm-docker/stable/cray-smd
+  pullPolicy: IfNotPresent
+
+tests:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/cray-smd-hmth-test
+    pullPolicy: IfNotPresent
+
+kubectl:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
+    tag: 1.19.15
+    pullPolicy: IfNotPresent
+
+schemaStorageClass: ceph-cephfs-external
+schemaAccessMode: ReadWriteMany
+
+hms_ca_uri: ""
+
+cray-service:
+  type: "Deployment"
+  nameOverride: "cray-smd"
+  fullnameOverride: "cray-smd"
+  replicaCount: 3
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - istio-ingressgateway
+                  - istio-ingressgateway-hmn
+            topologyKey: "kubernetes.io/hostname"
+            namespaces:
+              - istio-system
+  priorityClassName: "csm-high-priority-service"
+  containers:
+    cray-smd:
+      name: "cray-smd"
+      image:
+        repository: artifactory.algol60.net/csm-docker/stable/cray-smd
+      resources:
+        limits:
+          cpu: "16"
+          memory: 4Gi
+        requests:
+          cpu: "4"
+          memory: 256Mi
+      env:
+        # NOTE: overridden if POSTGRES_HOST is set
+        - name: SMD_DBHOST
+          value: cray-smd-postgres
+        # NOTE: overwritten if POSTGRES_PORT is set
+        - name: SMD_DBPORT
+          value: "5432"
+        - name: SMD_DBNAME
+          value: "hmsds"
+        - name: SMD_DBOPTS
+          value: ""
+        - name: SMD_DBUSER
+          valueFrom:
+            secretKeyRef:
+              name: hmsdsuser.cray-smd-postgres.credentials
+              key: username
+        - name: SMD_DBPASS
+          valueFrom:
+            secretKeyRef:
+              name: hmsdsuser.cray-smd-postgres.credentials
+              key: password
+        - name: RF_MSG_HOST
+          value: cray-shared-kafka-kafka-bootstrap.services.svc.cluster.local:9092:cray-dmtf-resource-event
+        - name: TLSCERT
+          value: ""
+        - name: TLSKEY
+          value: ""
+        - name: VAULT_ADDR
+          value: "http://cray-vault.vault:8200"
+        - name: VAULT_SKIP_VERIFY
+          value: "true"
+        - name: SMD_RVAULT
+          value: "true"
+        - name: SMD_WVAULT
+          value: "true"
+        - name: SMD_SLS_HOST
+          value: "http://cray-sls/v1"
+        - name: LOGLEVEL
+          value: "2"
+        - name: SMD_HWINVHIST_AGE_MAX_DAYS
+          value: "365"
+        - name: HMS_CONFIG_PATH
+          value: "/hms_config/hms_config.json"
+        - name: SMD_CA_URI
+          valueFrom:
+            configMapKeyRef:
+              name: smd-cacert-info
+              key: CA_URI
+        - name: SMD_HBTD_HOST
+          value: "http://cray-hbtd/hmi/v1"
+        - name: GOMAXPROCS
+          value: "8"
+      ports:
+        - name: http
+          containerPort: 27779
+      livenessProbe:
+        httpGet:
+          port: 27779
+          path: /hsm/v2/service/liveness
+        initialDelaySeconds: 5
+        periodSeconds: 10
+      readinessProbe:
+        httpGet:
+          port: 27779
+          path: /hsm/v2/service/ready
+        initialDelaySeconds: 15
+        periodSeconds: 30
+        timeoutSeconds: 10
+      volumeMounts:
+        - name: hms-config-vol
+          mountPath: /hms_config/
+        - name: cray-pki-cacert-vol
+          mountPath: /usr/local/cray-pki
+  volumes:
+    hms-config-vol:
+      name: hms-config-vol
+      configMap:
+        name: cray-hms-base-config
+        optional: true
+    cray-pki-cacert-vol:
+      name: cray-pki-cacert-vol
+      configMap:
+        name: cray-configmap-ca-public-key
+        optional: true
+  sqlCluster:
+    enabled: true
+    tls:
+      enabled: true
+    backup:
+      enabled: true
+      schedule: "10 0 * * *"  # Once per day at 12:10AM
+    users:
+      hmsdsuser: []
+    databases:
+      hmsds: hmsdsuser
+    volumeSize: 100Gi
+    resources:
+      limits:
+        cpu: "32"
+        memory: 32Gi
+      requests:
+        cpu: "4"
+        memory: 8Gi
+    podPriorityClassName: "csm-high-priority-service"
+  ingress:
+    enabled: true
+    prefix: "/apis/smd/"
+    uri: "/"
+  podAnnotations:
+    traffic.sidecar.istio.io/excludeOutboundPorts: "8082,9092,2181"

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -5,6 +5,7 @@ chartVersionToCSMVersion:
   ">=2.0.0": "~1.2.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
   ">=2.1.0": "~1.3.0"
   ">=4.0.0": ">=1.3.0"
+  ">=5.0.0": ">=1.6.0"
   
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -38,6 +39,7 @@ chartVersionToApplicationVersion:
   "4.0.0": "1.58.0"
   "4.0.1": "1.61.0"
   "4.0.2": "1.62.0"
+  "5.0.0": "2.2.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

This creates the v5.0 chart for HSM with v1 APIs removed.

## Issues and Related PRs

* Resolves [CASMHMS-5626](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5626)

## Testing

For testing, see https://github.com/Cray-HPE/hms-smd/pull/96

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable