### PR TITLE
CASMHMS-5747 Finish HSM CT Test Work for HMTH

### DIFF
--- a/changelog/v6.0.md
+++ b/changelog/v6.0.md
@@ -5,6 +5,13 @@ All notable changes to this project for v6.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.2] - 2023-02-28
+
+### Added
+
+- Added CT test coverage for most remaining APIs
+- Fixed several CT test bugs and made various improvements
+
 ## [6.0.1] - 2023-02-03
 
 ### Changed

--- a/charts/v6.0/cray-hms-smd/Chart.yaml
+++ b/charts/v6.0/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 6.0.1
+version: 6.0.2
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.5.0"
+appVersion: "2.6.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v6.0/cray-hms-smd/values.yaml
+++ b/charts/v6.0/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.5.0
-  testVersion: 2.5.0
+  appVersion: 2.6.0
+  testVersion: 2.6.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -44,6 +44,7 @@ chartVersionToApplicationVersion:
   "5.0.1": "2.5.0"
   "6.0.0": "2.2.0"
   "6.0.1": "2.5.0"
+  "6.0.2": "2.6.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This change includes many additions, updates, and fixes to the HSM CT tests:

* Finish test cases for HSM groups/add test cases for exclusive groups.
* Update hardware tests to no longer fail on unpopulated modules.
* Finish test cases for HSM ComponentEndpoints.
* Fix bug that caused certain validation functions to be silently skipped.
* Add tests for the DiscoveryStatus API.
* Add tests for the Discover API.
* Finish test cases for HSM partitions.
* Add tests for the memberships API.
* Add tests for the State Change Notifications API.

### Issues and Related PRs

* Resolves CASMHMS-5647.
* Resolves CASMHMS-5708.
* Resolves CASMHMS-5883.
* Resolves CASMHMS-5705.
* Partially resolves CASMHMS-5924.
* Resolves CASMHMS-5711.
* Resolves CASMHMS-5712.
* Resolves CASMHMS-5709.
* Resolves CASMHMS-5710.
* Resolves CASMHMS-5713.

### Testing

These changes were tested with local instances of the hms-simulation-environment using the small_mountain and one_of_each_blade hardware configurations, as well as in the runCT GitHub Actions pipeline.

### Risks and Mitigations

Low risk, testing changes only.