### PR TITLE
Fix node architecture discovery

### DIFF
--- a/changelog/v7.0.md
+++ b/changelog/v7.0.md
@@ -5,6 +5,11 @@ All notable changes to this project for v7.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.3] - 2023-05-19
+
+### Fixed
+
+- Node architecture discovery
 
 ## [7.0.2] - 2023-05-03
 

--- a/charts/v7.0/cray-hms-smd/Chart.yaml
+++ b/charts/v7.0/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.0.2
+version: 7.0.3
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.8.0"
+appVersion: "2.9.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v7.0/cray-hms-smd/values.yaml
+++ b/charts/v7.0/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.8.0
-  testVersion: 2.8.0
+  appVersion: 2.9.0
+  testVersion: 2.9.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -51,6 +51,7 @@ chartVersionToApplicationVersion:
   "7.0.0": "2.6.0"
   "7.0.1": "2.7.0"
   "7.0.2": "2.8.0"
+  "7.0.3": "2.9.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

This fixes node architecture discovery in HSM so that ARM nodes will have the correct ARCH field under `/State/Components`.

## Issues and Related PRs

* Resolves [CASMHMS-5958](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5958)

## Testing

For testing, see https://github.com/Cray-HPE/hms-smd/pull/114


## Risks and Mitigations

low


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable