### PR TITLE
Updated cray-service version to 10.0.2 for k8s 1.22

### DIFF
--- a/.github/workflows/k8s_api_checker.yaml
+++ b/.github/workflows/k8s_api_checker.yaml
@@ -4,8 +4,3 @@ jobs:
   k8s_api_checker:
     uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/k8s_api_checker.yaml@v2
     secrets: inherit
-    with:
-      # ignore-errors can be removed once the deprecated APIs are updated.
-      # Setting this to true causes the workflow to always complete as a success
-      # however the reports are still generated.
-      ignore-errors: true

--- a/changelog/v7.0.md
+++ b/changelog/v7.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v7.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.4] - 2023-06-21
+
+### Changed
+
+- Updated the cray-service chart to 10.0.2
+
 ## [7.0.3] - 2023-05-19
 
 ### Fixed

--- a/charts/v7.0/cray-hms-smd/Chart.yaml
+++ b/charts/v7.0/cray-hms-smd/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.0.3
+version: 7.0.4
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
   - "https://github.com/Cray-HPE/hms-smd"
 dependencies:
   - name: cray-service
-    version: "~10.0"
+    version: "~10.0.2"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
   - name: cray-postgresql
     version: "~1.0"

--- a/charts/v7.0/cray-hms-smd/Chart.yaml
+++ b/charts/v7.0/cray-hms-smd/Chart.yaml
@@ -7,10 +7,10 @@ sources:
   - "https://github.com/Cray-HPE/hms-smd"
 dependencies:
   - name: cray-service
-    version: "~10.0.2"
+    version: "~10.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
   - name: cray-postgresql
-    version: "~1.0.1"
+    version: "~1.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 maintainers:
   - name: Hardware Management

--- a/charts/v7.0/cray-hms-smd/Chart.yaml
+++ b/charts/v7.0/cray-hms-smd/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     version: "~10.0.2"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
   - name: cray-postgresql
-    version: "~1.0"
+    version: "~1.0.1"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 maintainers:
   - name: Hardware Management

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -52,6 +52,7 @@ chartVersionToApplicationVersion:
   "7.0.1": "2.7.0"
   "7.0.2": "2.8.0"
   "7.0.3": "2.9.0"
+  "7.0.4": "2.9.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

For the k8s 1.22 upgrade, this PR makes the following changes
* rebuilds to pick up base-charts:  cray-service 10.0.2, and cray-postgresql 1.0.1
* It documents which version is for k8s 1.22 or later
* Configures the deprecated k8s api checker to fail when there are deprecated APIs

### Issues and Related PRs

* Resolves [CASMHMS-5881](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-5881)

### Testing

Tested on:

* No additional testing beyond the automated tests


Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc)
Were continuous integration tests run? Y/N   If not, Why? N
Was an Upgrade tested?                 Y/N   If not, Why? N
Was a Downgrade tested?                Y/N   If not, Why? N


### Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable