### PR TITLE
Fix HSN NIC numbering

### DIFF
--- a/changelog/v7.0.md
+++ b/changelog/v7.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v7.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.5] - 2023-08-21
+
+### Changed
+
+- Fix HSN NIC numbering causing discovery errors.
+
 ## [7.0.4] - 2023-06-21
 
 ### Changed

--- a/charts/v7.0/cray-hms-smd/Chart.yaml
+++ b/charts/v7.0/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.0.4
+version: 7.0.5
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.9.0"
+appVersion: "2.11.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v7.0/cray-hms-smd/values.yaml
+++ b/charts/v7.0/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.9.0
-  testVersion: 2.9.0
+  appVersion: 2.11.0
+  testVersion: 2.11.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -53,6 +53,7 @@ chartVersionToApplicationVersion:
   "7.0.2": "2.8.0"
   "7.0.3": "2.9.0"
   "7.0.4": "2.9.0"
+  "7.0.5": "2.11.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Fixes a bug in HSN NIC numbering that is causing discovery errors when 4 HSN NICs are present in CSM 1.5 and 1.6.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5914](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5914)

## Testing

For testing see https://github.com/Cray-HPE/hms-smd/pull/118

## Risks and Mitigations

None


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
