### PR TITLE
Change FRU history to create 'Detected' events after 'Removed' events

### DIFF
--- a/changelog/v7.1.md
+++ b/changelog/v7.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v7.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.1] - 2023-09-26
+
+### Changed
+
+- Pull in updated HSM with FRU tracking fixes.
+
 ## [7.1.0] - 2023-08-05
 
 ### Changed

--- a/charts/v7.1/cray-hms-smd/Chart.yaml
+++ b/charts/v7.1/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.1.0
+version: 7.1.1
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.13.0"
+appVersion: "2.14.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v7.1/cray-hms-smd/values.yaml
+++ b/charts/v7.1/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.13.0
-  testVersion: 2.13.0
+  appVersion: 2.14.0
+  testVersion: 2.14.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -55,6 +55,7 @@ chartVersionToApplicationVersion:
   "7.0.4": "2.9.0"
   "7.0.5": "2.11.0"
   "7.1.0": "2.13.0"
+  "7.1.1": "2.14.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

HSM's FRU tracking was not creating a new 'Detected' event after a 'Removed' event if the same FRU was detected (Removed and put back in the same spot).

## Issues and Related PRs

* Resolves [CASMHMS-6096](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6096)

## Testing

For testing see https://github.com/Cray-HPE/hms-smd/pull/122

## Risks and Mitigations

Low


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable