### PR TITLE
Casmhms 6148.final

### DIFF
--- a/changelog/v7.0.md
+++ b/changelog/v7.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v7.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.11] - 2024-04-25
+
+### Fixed
+
+- CASMHMS-6148: Fixed power capping for Paradise
+
 ## [7.0.10] - 2024-04-16
 
 ### Changed

--- a/changelog/v7.0.md
+++ b/changelog/v7.0.md
@@ -5,11 +5,11 @@ All notable changes to this project for v7.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.0.11] - 2024-04-25
+## [7.0.11] - 2024-05-01
 
 ### Fixed
 
-- CASMHMS-6148: Fixed power capping for Paradise
+- CASMHMS-6148: Paradise discovery enhancements (including fixed power capping)
 
 ## [7.0.10] - 2024-04-16
 

--- a/changelog/v7.1.md
+++ b/changelog/v7.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v7.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.6] - 2024-04-25
+
+### Fixed
+
+- CASMHMS-6148: Fixed power capping for Paradise
+
 ## [7.1.5] - 2024-04-03
 
 ### Fixed

--- a/changelog/v7.1.md
+++ b/changelog/v7.1.md
@@ -5,11 +5,11 @@ All notable changes to this project for v7.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.1.6] - 2024-04-25
+## [7.1.6] - 2024-05-01
 
 ### Fixed
 
-- CASMHMS-6148: Fixed power capping for Paradise
+- CASMHMS-6148: Paradise discovery enhancements (including fixed power capping)
 
 ## [7.1.5] - 2024-04-03
 

--- a/charts/v7.0/cray-hms-smd/Chart.yaml
+++ b/charts/v7.0/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.0.10
+version: 7.0.11
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.11.6"
+appVersion: "2.11.7"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v7.0/cray-hms-smd/values.yaml
+++ b/charts/v7.0/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.11.6
-  testVersion: 2.11.6
+  appVersion: 2.11.7
+  testVersion: 2.11.7
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/charts/v7.1/cray-hms-smd/Chart.yaml
+++ b/charts/v7.1/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.1.5
+version: 7.1.6
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.17.0"
+appVersion: "2.18.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v7.1/cray-hms-smd/values.yaml
+++ b/charts/v7.1/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.17.0
-  testVersion: 2.17.0
+  appVersion: 2.18.0
+  testVersion: 2.18.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -59,12 +59,14 @@ chartVersionToApplicationVersion:
   "7.0.8": "2.11.5"
   "7.0.9": "2.11.6"
   "7.0.10": "2.11.6"
+  "7.0.11": "2.11.7"
   "7.1.0": "2.13.0"
   "7.1.1": "2.14.0"
   "7.1.2": "2.15.0"
   "7.1.3": "2.16.0"
   "7.1.4": "2.16.0"
   "7.1.5": "2.17.0"
+  "7.1.6": "2.18.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

There are a number of discovery changes in this PR related to Foxconn Paradise discovery.

The Paradise redfish Power endpoint presents the consumed watts value as a float. All prior platforms have presented it as an integer value and thus the smd data structure for holding it declared it as an int. This caused json.Unmarshal() to fail on Paradise because it enforces strict type checking.  The fix here is to change the int type to an interface{} type so that it can hold a value of any type. We then convert any floats we read to an int (by rounding). We chose to do this rather than simply changing the type from an int to a float so that we don't break any customer code that may be doing the same thing we were doing (expecting an int rather than a float).

During chassis discovery, we now skip discovery of power supplies for all chassis except Baseboard_0 as it contains everything necessary.  The PSU0 and PSU1 chassis contain redundant data.  When node power is off, due to a regression described in PRDIS-198, the Power endpoint becomes inaccessible and cause long timeouts.  Since the only chassis we need to query for power supplies is Baseboard_0, we skip all the others and avoid all but one of the timeouts.

For power capping, we query the Power endpoint in the Processor_Module_0 chassis during the Systems discovery phase.  It is the control provided to us by Foxconn.  Power capping will only be allowed when node power is on.  If a power cap is in place when the node is powered off, it will be reset when the node is powered back on again.

We use the Baseboard_0 chassis for discovery of assemblies and network adapters for Foxconn Paradise.

Adopted app version 2.11.7 for CSM 1.5.2 (helm chart 7.0.11)
Adopted app version 2.18.0 for CSM 1.6 (helm chart 7.1.6)

## Issues and Related PRs

* Resolves CASMHMS-6148

## Testing

Tested on:

  * tyr

Test description:

Ran discovery against Paradise, DL325, and Bard Peak node/BMC types with power on and power off.

Verified both capmc and PCS can now power cap Paradise nodes.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? Y
- Was upgrade tested? Y
- Was downgrade tested? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable