### PR TITLE
CASMHMS-6201: Updated tavern tests to handle Foxconn Paradise ethernet interface names

### DIFF
--- a/changelog/v7.0.md
+++ b/changelog/v7.0.md
@@ -5,11 +5,17 @@ All notable changes to this project for v7.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.13] - 2024-05-06
+
+### Fixed
+
+- Updated tavern tests to handle Foxconn Paradise ethernet interface names
+
 ## [7.0.11] - 2024-05-01
 
 ### Fixed
 
-- CASMHMS-6148: Paradise discovery enhancements (including fixed power capping)
+- Paradise discovery enhancements (including fixed power capping)
 
 ## [7.0.10] - 2024-04-16
 

--- a/changelog/v7.1.md
+++ b/changelog/v7.1.md
@@ -5,11 +5,17 @@ All notable changes to this project for v7.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.8] - 2024-05-06
+
+### Fixed
+
+- Updated tavern tests to handle Foxconn Paradise ethernet interface names
+
 ## [7.1.6] - 2024-05-01
 
 ### Fixed
 
-- CASMHMS-6148: Paradise discovery enhancements (including fixed power capping)
+- Paradise discovery enhancements (including fixed power capping)
 
 ## [7.1.5] - 2024-04-03
 

--- a/charts/v7.0/cray-hms-smd/Chart.yaml
+++ b/charts/v7.0/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.0.11
+version: 7.0.13
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.11.7"
+appVersion: "2.11.9"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v7.0/cray-hms-smd/values.yaml
+++ b/charts/v7.0/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.11.7
-  testVersion: 2.11.7
+  appVersion: 2.11.9
+  testVersion: 2.11.9
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/charts/v7.1/cray-hms-smd/Chart.yaml
+++ b/charts/v7.1/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.1.6
+version: 7.1.8
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.18.0"
+appVersion: "2.20.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v7.1/cray-hms-smd/values.yaml
+++ b/charts/v7.1/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.18.0
-  testVersion: 2.18.0
+  appVersion: 2.20.0
+  testVersion: 2.20.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -60,6 +60,7 @@ chartVersionToApplicationVersion:
   "7.0.9": "2.11.6"
   "7.0.10": "2.11.6"
   "7.0.11": "2.11.7"
+  "7.0.13": "2.11.9"
   "7.1.0": "2.13.0"
   "7.1.1": "2.14.0"
   "7.1.2": "2.15.0"
@@ -67,6 +68,7 @@ chartVersionToApplicationVersion:
   "7.1.4": "2.16.0"
   "7.1.5": "2.17.0"
   "7.1.6": "2.18.0"
+  "7.1.8": "2.20.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Updated regex patterns in the tavern tests to handle the new Foxconn Paradise ethernet interface names.  Without these changes, the SMD functional tests were failing on systems with Foxconn Paradise hardware.

Adopted app version 2.11.9 for CSM 1.5.2 (helm chart 7.0.13)
Adopted app version 2.20.0 for CSM 1.6 (helm chart 7.1.8)

## Issues and Related PRs

* Resolves [CASMHMS-6201](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6201)

## Testing

Tested on:

  * tyr

Test description:

Aftur upgrading SMD with changes, verified smoke and functional tests passed when running:

`/opt/cray/csm/scripts/hms_verification/run_hms_ct_tests.sh -t hsm`

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? :
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable