### PR TITLE
CASMHMS-6199: Add 'Zone' chassis type to tavern test

### DIFF
--- a/changelog/v7.0.md
+++ b/changelog/v7.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v7.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.15] - 2024-05-15
+
+### Fixed
+
+- Add 'Zone' chassis type to tavern test
+
 ## [7.0.14] - 2024-05-15
 
 ### Fixed

--- a/changelog/v7.0.md
+++ b/changelog/v7.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v7.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.14] - 2024-05-10
+
+### Fixed
+
+- Pick appropriate chassis to act as node enclosure for Paradise
+
 ## [7.0.11] - 2024-05-01
 
 ### Fixed

--- a/changelog/v7.0.md
+++ b/changelog/v7.0.md
@@ -5,7 +5,7 @@ All notable changes to this project for v7.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.0.14] - 2024-05-10
+## [7.0.14] - 2024-05-15
 
 ### Fixed
 

--- a/changelog/v7.1.md
+++ b/changelog/v7.1.md
@@ -5,7 +5,7 @@ All notable changes to this project for v7.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.1.9] - 2024-05-10
+## [7.1.9] - 2024-05-15
 
 ### Fixed
 

--- a/changelog/v7.1.md
+++ b/changelog/v7.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v7.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.9] - 2024-05-10
+
+### Fixed
+
+- Pick appropriate chassis to act as node enclosure for Paradise
+
 ## [7.1.6] - 2024-05-01
 
 ### Fixed

--- a/changelog/v7.1.md
+++ b/changelog/v7.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v7.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.10] - 2024-05-15
+
+### Fixed
+
+- Add 'Zone' chassis type to tavern test
+
 ## [7.1.9] - 2024-05-15
 
 ### Fixed

--- a/charts/v7.0/cray-hms-smd/Chart.yaml
+++ b/charts/v7.0/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.0.11
+version: 7.0.14
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.11.7"
+appVersion: "2.11.10"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v7.0/cray-hms-smd/Chart.yaml
+++ b/charts/v7.0/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.0.14
+version: 7.0.15
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.11.10"
+appVersion: "2.11.11"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v7.0/cray-hms-smd/values.yaml
+++ b/charts/v7.0/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.11.7
-  testVersion: 2.11.7
+  appVersion: 2.11.10
+  testVersion: 2.11.10
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/charts/v7.0/cray-hms-smd/values.yaml
+++ b/charts/v7.0/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.11.10
-  testVersion: 2.11.10
+  appVersion: 2.11.11
+  testVersion: 2.11.11
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/charts/v7.1/cray-hms-smd/Chart.yaml
+++ b/charts/v7.1/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.1.9
+version: 7.1.10
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.21.0"
+appVersion: "2.22.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v7.1/cray-hms-smd/Chart.yaml
+++ b/charts/v7.1/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.1.6
+version: 7.1.9
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.18.0"
+appVersion: "2.21.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v7.1/cray-hms-smd/values.yaml
+++ b/charts/v7.1/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.18.0
-  testVersion: 2.18.0
+  appVersion: 2.21.0
+  testVersion: 2.21.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/charts/v7.1/cray-hms-smd/values.yaml
+++ b/charts/v7.1/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.21.0
-  testVersion: 2.21.0
+  appVersion: 2.22.0
+  testVersion: 2.22.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -64,6 +64,7 @@ chartVersionToApplicationVersion:
   "7.0.12": "2.11.8"
   "7.0.13": "2.11.9"
   "7.0.14": "2.11.10"
+  "7.0.15": "2.11.11"
   "7.1.0": "2.13.0"
   "7.1.1": "2.14.0"
   "7.1.2": "2.15.0"
@@ -74,6 +75,7 @@ chartVersionToApplicationVersion:
   "7.1.7": "2.19.0"
   "7.1.8": "2.20.0"
   "7.1.9": "2.21.0"
+  "7.1.10": "2.22.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -60,6 +60,7 @@ chartVersionToApplicationVersion:
   "7.0.9": "2.11.6"
   "7.0.10": "2.11.6"
   "7.0.11": "2.11.7"
+  "7.0.14": "2.11.10"
   "7.1.0": "2.13.0"
   "7.1.1": "2.14.0"
   "7.1.2": "2.15.0"
@@ -67,6 +68,7 @@ chartVersionToApplicationVersion:
   "7.1.4": "2.16.0"
   "7.1.5": "2.17.0"
   "7.1.6": "2.18.0"
+  "7.1.9": "2.21.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

I neglected to run the functional tests when pushing up my last CASMHMS-6199 changes.  After pushing them up, I ran the functional tests and found that they failed because of the new Paradise chassis type 'Zone'.  This change updates the test so that type 'Zone' is recognized, and will not fail the test.

Adopted app version 2.11.11 for CSM 1.5.2 (helm chart 7.0.15)
Adopted app version 2.22.0 for CSM 1.6 (helm chart 7.1.10)

## Issues and Related PRs

* Resolves: CASMHMS-6199

## Testing

Tested on:

  * tyr

Test description:

Ran '/opt/cray/csm/scripts/hms_verification/run_hms_ct_tests.sh -t hsm' and verified the tests ran successfully.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable