### PR TITLE
CASMHMS-5838: Fix bugs that break bulk component role/subrole updates

### DIFF
--- a/.github/workflows/build_and_release_charts.yaml
+++ b/.github/workflows/build_and_release_charts.yaml
@@ -2,7 +2,7 @@ name: Build and Publish Helm charts
 on: [push, pull_request, workflow_dispatch]
 jobs:
   build_and_release:
-    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/build_and_release_charts.yaml@v2
+    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/build_and_release_charts.yaml@v3
     with:
       artifactory-component: cray-hms-smd
       target-branch: main

--- a/changelog/v7.0.md
+++ b/changelog/v7.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v7.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.16] - 2024-05-28
+
+### Fixed
+
+- Fixed bugs preventing bulk component role/subrole updates.
+
 ## [7.0.15] - 2024-05-15
 
 ### Fixed

--- a/changelog/v7.1.md
+++ b/changelog/v7.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v7.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.11] - 2024-05-28
+
+### Fixed
+
+- Fixed bugs preventing bulk component role/subrole updates.
+
 ## [7.1.10] - 2024-05-15
 
 ### Fixed

--- a/charts/v7.0/cray-hms-smd/Chart.yaml
+++ b/charts/v7.0/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.0.15
+version: 7.0.16
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.11.11"
+appVersion: "2.11.12"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v7.0/cray-hms-smd/values.yaml
+++ b/charts/v7.0/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.11.11
-  testVersion: 2.11.11
+  appVersion: 2.11.12
+  testVersion: 2.11.12
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/charts/v7.1/cray-hms-smd/Chart.yaml
+++ b/charts/v7.1/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.1.10
+version: 7.1.11
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.22.0"
+appVersion: "2.23.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v7.1/cray-hms-smd/values.yaml
+++ b/charts/v7.1/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.22.0
-  testVersion: 2.22.0
+  appVersion: 2.23.0
+  testVersion: 2.23.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -65,6 +65,7 @@ chartVersionToApplicationVersion:
   "7.0.13": "2.11.9"
   "7.0.14": "2.11.10"
   "7.0.15": "2.11.11"
+  "7.0.16": "2.11.12"
   "7.1.0": "2.13.0"
   "7.1.1": "2.14.0"
   "7.1.2": "2.15.0"
@@ -76,6 +77,7 @@ chartVersionToApplicationVersion:
   "7.1.8": "2.20.0"
   "7.1.9": "2.21.0"
   "7.1.10": "2.22.0"
+  "7.1.11": "2.23.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
This is to pull in these fixes:

CSM 1.5.2: https://github.com/Cray-HPE/hms-smd/pull/148
CSM 1.6.0: https://github.com/Cray-HPE/hms-smd/pull/149

The main code change PR is the one for CSM 1.4.5, but for that version we're not making a new chart, just a new image:
https://github.com/Cray-HPE/hms-smd/pull/147