### PR TITLE
CASMTRIAGE-7079: Paradise: Fixed functional hardware test to pass processor types of "FPGA"

### DIFF
--- a/changelog/v7.0.md
+++ b/changelog/v7.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v7.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.19] - 2024-06-17
+
+### Fixed
+
+-  Paradise: Fixed functional hardware test to pass processor types of "FPGA"
+
 ## [7.0.18] - 2024-06-06
 
 ### Fixed

--- a/changelog/v7.1.md
+++ b/changelog/v7.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v7.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.14] - 2024-06-17
+
+### Fixed
+
+-  Paradise: Fixed functional hardware test to pass processor types of "FPGA"
+
 ## [7.1.13] - 2024-06-06
 
 ### Fixed

--- a/charts/v7.0/cray-hms-smd/Chart.yaml
+++ b/charts/v7.0/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.0.18
+version: 7.0.19
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.11.14"
+appVersion: "2.11.15"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v7.0/cray-hms-smd/values.yaml
+++ b/charts/v7.0/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.11.14
-  testVersion: 2.11.14
+  appVersion: 2.11.15
+  testVersion: 2.11.15
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/charts/v7.1/cray-hms-smd/Chart.yaml
+++ b/charts/v7.1/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.1.13
+version: 7.1.14
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.25.0"
+appVersion: "2.26.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v7.1/cray-hms-smd/values.yaml
+++ b/charts/v7.1/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.25.0
-  testVersion: 2.25.0
+  appVersion: 2.26.0
+  testVersion: 2.26.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -68,6 +68,7 @@ chartVersionToApplicationVersion:
   "7.0.16": "2.11.12"
   "7.0.17": "2.11.13"
   "7.0.18": "2.11.14"
+  "7.0.19": "2.11.15"
   "7.1.0": "2.13.0"
   "7.1.1": "2.14.0"
   "7.1.2": "2.15.0"
@@ -82,6 +83,7 @@ chartVersionToApplicationVersion:
   "7.1.11": "2.23.0"
   "7.1.12": "2.24.0"
   "7.1.13": "2.25.0"
+  "7.1.14": "2.26.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Hardare tavern test was failing when run against Paradise.  Paradise includes a new processor type "FPGA" that was not expected by the test.  The change here is to add "FPGA" as a valid processor type.  This was not hit previously because the tavern tests do not test against each node type on a system.  Node selection is random, and we got unlucky that no Paradise node had been previously chosen.

Adopted app version 2.11.15 for CSM 1.5.2 (helm chart 7.0.19)
Adopted app version 2.26.0 for CSM 1.6 (helm chart 7.1.14)

## Issues and Related PRs

* Resolves [CASMTRIAGE-7079](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7079)
* Change will also be needed in `master` (ie. 1.6)

## Testing

Tested on:

  * `tyr`

Test description:

Made a temporary change to the test_hardware.tavern.yaml file:

` -      url: "{hsm_base_url}/hsm/v2/State/Components?type=Node"`
` +      url: "{hsm_base_url}/hsm/v2/State/Components?type=Node&id=x3000c0s33b2n0"`

This ensured the test was run against a Paradise node.  The test then passed.  I removed this code change before making the final PR.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? Y
- Was upgrade tested? Y
- Was downgrade tested? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable