### PR TITLE
CASMHMS-6261: Updated dependences for Kubernetes 1.24

### DIFF
--- a/changelog/v7.1.md
+++ b/changelog/v7.1.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update cray-service chart to ~11.0.0 and docker-kubectl image to 1.24.17
+- Update cray-service chart to ~11.0 and docker-kubectl image to 1.24.17
 
 ## [7.1.16] - 2024-07-22
 

--- a/changelog/v7.1.md
+++ b/changelog/v7.1.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update cray-service chart to ~10.0.6 and docker-kubectl image to 1.24.17
+- Update cray-service chart to ~11.0.0 and docker-kubectl image to 1.24.17
 
 ## [7.1.16] - 2024-07-22
 

--- a/changelog/v7.1.md
+++ b/changelog/v7.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v7.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.17] - 2024-08-30
+
+### Changed
+
+- Update cray-service chart to ~10.0.6 and docker-kubectl image to 1.24.17
+
 ## [7.1.16] - 2024-07-22
 
 ### Fixed

--- a/charts/v7.1/cray-hms-smd/Chart.yaml
+++ b/charts/v7.1/cray-hms-smd/Chart.yaml
@@ -7,7 +7,7 @@ sources:
   - "https://github.com/Cray-HPE/hms-smd"
 dependencies:
   - name: cray-service
-    version: "~11.0.0"
+    version: "~11.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
   - name: cray-postgresql
     version: "~1.0"

--- a/charts/v7.1/cray-hms-smd/Chart.yaml
+++ b/charts/v7.1/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.1.16
+version: 7.1.17
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:

--- a/charts/v7.1/cray-hms-smd/Chart.yaml
+++ b/charts/v7.1/cray-hms-smd/Chart.yaml
@@ -7,7 +7,7 @@ sources:
   - "https://github.com/Cray-HPE/hms-smd"
 dependencies:
   - name: cray-service
-    version: "~10.0"
+    version: "~10.0.6"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
   - name: cray-postgresql
     version: "~1.0"

--- a/charts/v7.1/cray-hms-smd/Chart.yaml
+++ b/charts/v7.1/cray-hms-smd/Chart.yaml
@@ -7,7 +7,7 @@ sources:
   - "https://github.com/Cray-HPE/hms-smd"
 dependencies:
   - name: cray-service
-    version: "~10.0.6"
+    version: "~11.0.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
   - name: cray-postgresql
     version: "~1.0"

--- a/charts/v7.1/cray-hms-smd/values.yaml
+++ b/charts/v7.1/cray-hms-smd/values.yaml
@@ -23,7 +23,7 @@ tests:
 kubectl:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-    tag: 1.19.15
+    tag: 1.24.17
     pullPolicy: IfNotPresent
 
 schemaStorageClass: ceph-cephfs-external

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -8,7 +8,7 @@ chartVersionToCSMVersion:
   ">=5.0.0": ">=1.4.0" # CSM 1.4.0 is locked on chart version 5.0.0 and using app version 2.2.*
                        # If chart changes are needed a 5.0.4 chart with app 2.2.* is likely possible
   ">=6.0.0": ">=1.5.0" # CSM 1.5.0 is using chart 7.0.* and app version 2.11.*
-  ">=7.1.0": ">=1.6.0"
+  ">=7.1.0": ">=1.6.0" # CSM 1.6.0 or later
   
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -88,6 +88,7 @@ chartVersionToApplicationVersion:
   "7.1.14": "2.26.0"
   "7.1.15": "2.27.0"
   "7.1.16": "2.28.0"
+  "7.1.17": "2.28.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -14,7 +14,7 @@ chartVersionToCSMVersion:
   ">=4.0.0": ">=1.3.0"
   ">=5.0.0": ">=1.4.0" # CSM 1.4.0 is locked on chart version 5.0.0 and using app version 2.2.*
                        # If chart changes are needed a 5.0.4 chart with app 2.2.* is likely possible
-  ">=6.0.0": ">=1.5.0" # Next app change should bump app version 2.11.x
+  ">=6.0.0": ">=1.5.0" # CSM 1.5 is locked to app version 2.11.*
   ">=7.1.0": ">=1.6.0"
   
 # The application version must be compliant to semantic versioning.

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -1,14 +1,21 @@
 ---
 # CSM Version is not really following semver.
 chartVersionToCSMVersion:
+  # Summary:
+  #   Chart Version: 2.0.0 <= x.y.z < 2.1.0, CSM Version: 1.2.0 <= x.y.z < 1.3.0
+  #   Chart Version: 2.1.0 <= x.y.z < 5.0.0, CSM Version: 1.3.0 <= x.y.z < 1.4.0
+  #   Chart Version: 5.0.0 <= x.y.z < 6.0.0, CSM Version: 1.4.0 <= x.y.z < 1.5.0
+  #   Chart Version: 6.0.0 <= x.y.z < 7.1.0, CSM Version: 1.5.0 <= x.y.z < 1.6.0
+  #   Chart Version: 7.1.0 <= x.y.z,         CSM Version: 1.6.0 <= x.y.z
+  #
   # Chart version: CSM version
-  ">=2.0.0": "~1.2.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
+  ">=2.0.0": "~1.2.0"
   ">=2.1.0": "~1.3.0"
   ">=4.0.0": ">=1.3.0"
   ">=5.0.0": ">=1.4.0" # CSM 1.4.0 is locked on chart version 5.0.0 and using app version 2.2.*
                        # If chart changes are needed a 5.0.4 chart with app 2.2.* is likely possible
-  ">=6.0.0": ">=1.5.0" # CSM 1.5.0 is using chart 7.0.* and app version 2.11.*
-  ">=7.1.0": ">=1.6.0" # CSM 1.6.0 or later
+  ">=6.0.0": ">=1.5.0"
+  ">=7.1.0": ">=1.6.0"
   
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -14,7 +14,7 @@ chartVersionToCSMVersion:
   ">=4.0.0": ">=1.3.0"
   ">=5.0.0": ">=1.4.0" # CSM 1.4.0 is locked on chart version 5.0.0 and using app version 2.2.*
                        # If chart changes are needed a 5.0.4 chart with app 2.2.* is likely possible
-  ">=6.0.0": ">=1.5.0"
+  ">=6.0.0": ">=1.5.0" # Next app change should bump app version 2.11.x
   ">=7.1.0": ">=1.6.0"
   
 # The application version must be compliant to semantic versioning.


### PR DESCRIPTION
## Summary and Scope

In CSM 1.6 Kubernetes is being updated to 1.24

- Updated the cray-service chart to 11.0.0
- Updated docker-kubectl to 1.24.17

Adopted helm chart 7.1.17 for this.  There was no change in app version.

## Issues and Related PRs

* Resolves [CASMHMS-6261](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6261)

## Testing

Tested on:

  * `fanta` (running Kubernetes v1.24.17)

Test description:

All testing was done with the new cray-service 10.0.6.  After testing completed, was asked to use 11.0.0 instead of 10.0.6 but was informed that no testing of 11.0.0 was required to be done if already tested with 10.0.6 because it is the exact same, just a different version number.

- Upgraded to new chart with 'helm upgrade'
- Because pods don't restart after upgrade if there was no container change, manually restarted them with 'kubectl rollout restart deployment'
- Verified no errors in chart upgrade or restart of pods
- Ran test suite 'run_hms_ct_tests.sh -t hsm' and verified no failures
- Checked logs from service to verify nothing unusual present

Test Checklist:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable