### PR TITLE
CASMHMS-6279: Fix tavern functional test for new eth int name and fix CT/Unit test pipeline

### DIFF
--- a/changelog/v7.1.md
+++ b/changelog/v7.1.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed failing tavern test for ethernet interfaces named DC[0-9A-Za-z]+
+- Fixed failing tavern test for ethernet interfaces named DC[0-9A-Za-z]+ and updated CT/Unit tests to use "docker compose" rather than "docker-compose"
 
 ## [7.1.17] - 2024-08-30
 

--- a/changelog/v7.1.md
+++ b/changelog/v7.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v7.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.18] - 2024-09-18
+
+### Fixed
+
+- Fixed failing tavern test for ethernet interfaces named DC[0-9A-Za-z]+
+
 ## [7.1.17] - 2024-08-30
 
 ### Changed

--- a/charts/v7.1/cray-hms-smd/Chart.yaml
+++ b/charts/v7.1/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.1.17
+version: 7.1.18
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.28.0"
+appVersion: "2.29.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v7.1/cray-hms-smd/values.yaml
+++ b/charts/v7.1/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.28.0
-  testVersion: 2.28.0
+  appVersion: 2.29.0
+  testVersion: 2.29.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -96,6 +96,7 @@ chartVersionToApplicationVersion:
   "7.1.15": "2.27.0"
   "7.1.16": "2.28.0"
   "7.1.17": "2.28.0"
+  "7.1.18": "2.29.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Changes included in this fix:

- Updated tavern functional test to match the ethernet interface name that the customer in the CAST is using
- Fix broken pipeline CT/Unit tests by using "docker compose" instead of "docker-compose"

Adopted app version 2.29.0 for CSM 1.6 (helm chart 7.1.18)

## Issues and Related PRs

* Resolves [CASMHMS-6279](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6279)

## Testing

Tested on:

  * `tyr`

Test description:

Upgraded to new chart on tyr and ran `run_hms_ct_tests.sh -t hsm` to ensure functional tests still ran correctly.  I'm not aware of any systems that have a similar interface name as the one described in the CAST so that aspect could not be tested.  However, this is an extremely simple change very unlikely to be incorrect or cause issues.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable