### PR TITLE
CASMHMS-6324: Added support for ppprof builds

### DIFF
--- a/changelog/v7.1.md
+++ b/changelog/v7.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v7.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.20] - 2025-01-08
+
+### Added
+
+- Added support for ppprof builds
+
 ## [7.1.19] - 2024-12-13
 
 ### Fixed

--- a/charts/v7.1/cray-hms-smd/Chart.yaml
+++ b/charts/v7.1/cray-hms-smd/Chart.yaml
@@ -15,6 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.31.0"
+appVersion: "2.31.0"  # update pprof image version below as well
 annotations:
+  artifacthub.io/images: |-
+    - name: cray-smd-pprof
+      image: artifactory.algol60.net/csm-docker/stable/cray-smd-pprof:2.31.0
   artifacthub.io/license: "MIT"

--- a/charts/v7.1/cray-hms-smd/Chart.yaml
+++ b/charts/v7.1/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.1.19
+version: 7.1.20
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.30.0"
+appVersion: "2.31.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v7.1/cray-hms-smd/values.yaml
+++ b/charts/v7.1/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.30.0
-  testVersion: 2.30.0
+  appVersion: 2.31.0
+  testVersion: 2.31.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -99,6 +99,7 @@ chartVersionToApplicationVersion:
   "7.1.17": "2.28.0"
   "7.1.18": "2.29.0"
   "7.1.19": "2.30.0"
+  "7.1.20": "2.31.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Added support for building a pprof enabled image.  Profiling adds runtime overhead so the pprof enabled image is not used by default.  It is meant to be a debug tool.  In order to use the enabled pprof image, edit the deployment and append "-pprof" to the image name.  For unstable developer builds, be sure to change the built timestamp as well.

Adopted app version 2.31.0 for CSM 1.6.1 (helm chart 7.1.20)

## Issues and Related PRs

* Resolves [CASMHMS-6324](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6324)

## Testing

Tested on:

  * `mug`

Test description:

- Deployed service with pprof enabled - confirmed pprof functionality
- Deployed services with pprof disabled - confirmed pprof support not built into binary
- Functional tests (if they exist) was successfully ran with and without pprof enabled

Test Checklist:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable