### PR TITLE
CASMHMS-5678: Update image and module dependencies

### DIFF
--- a/changelog/v7.2.md
+++ b/changelog/v7.2.md
@@ -5,7 +5,7 @@ All notable changes to this project for v7.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.2.0] - 2025-01-28
+## [7.2.0] - 2025-01-17
 
 ### Security
 

--- a/changelog/v7.2.md
+++ b/changelog/v7.2.md
@@ -1,0 +1,12 @@
+# Changelog for v7.2
+
+All notable changes to this project for v7.2.Z will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [7.2.0] - 2025-01-28
+
+### Security
+
+- Update image and module dependencies

--- a/changelog/v7.2.md
+++ b/changelog/v7.2.md
@@ -5,7 +5,7 @@ All notable changes to this project for v7.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.2.0] - 2025-01-17
+## [7.2.0] - 2025-01-22
 
 ### Security
 

--- a/changelog/v7.2.md
+++ b/changelog/v7.2.md
@@ -5,7 +5,7 @@ All notable changes to this project for v7.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.2.0] - 2025-01-22
+## [7.2.0] - 2025-01-24
 
 ### Security
 

--- a/charts/v7.2/cray-hms-smd/.gitignore
+++ b/charts/v7.2/cray-hms-smd/.gitignore
@@ -1,0 +1,3 @@
+# by default we'll ignore any subcharts included, but simply adjust this if need be
+charts/*
+Chart.lock

--- a/charts/v7.2/cray-hms-smd/Chart.yaml
+++ b/charts/v7.2/cray-hms-smd/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: "cray-hms-smd"
+version: 7.2.0
+description: "Kubernetes resources for cray-hms-smd"
+home: "https://github.com/Cray-HPE/hms-smd-charts"
+sources:
+  - "https://github.com/Cray-HPE/hms-smd"
+dependencies:
+  - name: cray-service
+    version: "~11.0"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+  - name: cray-postgresql
+    version: "~1.0"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+maintainers:
+  - name: Hardware Management
+    url: https://github.com/orgs/Cray-HPE/teams/hardware-management
+appVersion: "2.33.0"  # update pprof image version below as well
+annotations:
+  artifacthub.io/images: |-
+    - name: cray-smd-pprof
+      image: artifactory.algol60.net/csm-docker/stable/cray-smd-pprof:2.33.0
+  artifacthub.io/license: "MIT"

--- a/charts/v7.2/cray-hms-smd/templates/NOTES.txt
+++ b/charts/v7.2/cray-hms-smd/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Installation info for chart {{ include "cray-service.name" . }}:

--- a/charts/v7.2/cray-hms-smd/templates/_helpers.tpl
+++ b/charts/v7.2/cray-hms-smd/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{/*
+Add helper methods here for your chart
+*/}}

--- a/charts/v7.2/cray-hms-smd/templates/configmap.yaml
+++ b/charts/v7.2/cray-hms-smd/templates/configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+data:
+  hms_config.json: |-
+    {
+       "HMSExtendedDefinitions":{
+          "Role":[
+             "Compute",
+             "Service",
+             "System",
+             "Application",
+             "Storage",
+             "Management"
+          ],
+          "SubRole":[
+             "Worker",
+             "Master",
+             "Storage",
+             "UAN",
+             "Gateway",
+             "LNETRouter",
+             "Visualization",
+             "UserDefined"
+          ]
+       }
+    }
+kind: ConfigMap
+metadata:
+  name: cray-hms-base-config
+  namespace: services
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: smd-cacert-info
+data:
+  CA_URI: "{{ .Values.hms_ca_uri }}"
+

--- a/charts/v7.2/cray-hms-smd/templates/destinationrules.yaml
+++ b/charts/v7.2/cray-hms-smd/templates/destinationrules.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "cray-hms-smd-shared-kafkarule"
+  labels:
+    app.kubernetes.io/name: cray-hms-smd
+spec:
+  host: "cray-shared-kafka-kafka-bootstrap.services.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "cray-smd-service"
+  labels:
+    app.kubernetes.io/name: cray-hms-smd
+spec:
+  host: "cray-smd"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/charts/v7.2/cray-hms-smd/templates/hook-serviceaccount.yaml
+++ b/charts/v7.2/cray-hms-smd/templates/hook-serviceaccount.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cray-smd-job-deleter
+  namespace: services
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cray-smd-job-deleter
+  namespace: services
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+rules:
+- apiGroups: ["batch", ""]
+  resources: ["jobs", "pods"]
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cray-smd-job-deleter
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cray-smd-job-deleter
+subjects:
+  - kind: ServiceAccount
+    name: cray-smd-job-deleter
+    namespace: services

--- a/charts/v7.2/cray-hms-smd/templates/jobs.yaml
+++ b/charts/v7.2/cray-hms-smd/templates/jobs.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cray-smd-job-deleter
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "0"
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: “false”
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: "cray-smd-job-deleter"
+      containers:
+        - name: job-deleter
+          image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
+          imagePullPolicy: "{{ .Values.kubectl.image.pullPolicy }}"
+          command:
+          - /bin/sh
+          - -c
+          - set -x;
+            echo "Deleting smd-init Job";
+            kubectl -n services delete job cray-smd-init;
+            while [ "`kubectl -n services get pods -l app=cray-smd-init -o jsonpath='{.items}'`" != "[]" ];
+            do
+              echo "Waiting for previous job to be removed entirely...";
+              sleep 1;
+            done;
+            echo "Old job deleted.";
+            exit 0
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cray-smd-init
+  labels:
+    app: cray-smd-init
+spec:
+  ttlSecondsAfterFinished: {{ .Values.smdInitJobTTL }}
+  template:
+    metadata:
+      labels:
+        app: cray-smd-init
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 65534
+      serviceAccountName: "jobs-watcher"
+      containers:
+        - name: cray-smd-init
+          image: {{ .Values.image.repository }}:{{ .Values.global.appVersion }}
+          env:
+            # NOTE: overridden in container if POSTGRES_HOST is set
+            - name: SMD_DBHOST
+              value: cray-smd-postgres
+            # NOTE: overwritten in container if POSTGRES_PORT is set
+            - name: SMD_DBPORT
+              value: "5432"
+            - name: SMD_DBNAME
+              value: "hmsds"
+            - name: SMD_DBUSER
+              valueFrom:
+                secretKeyRef:
+                  name: hmsdsuser.cray-smd-postgres.credentials
+                  key: username
+            - name: SMD_DBPASS
+              valueFrom:
+                secretKeyRef:
+                  name: hmsdsuser.cray-smd-postgres.credentials
+                  key: password
+            - name: SMD_DBOPTS
+              value: ""
+          volumeMounts:
+            - mountPath: "/persistent_migrations"
+              name: schema
+          command: ["/entrypoint.sh"]
+          args: ["smd-init"]
+      volumes:
+        - name: schema
+          persistentVolumeClaim:
+            claimName: cray-smd-init-pvc

--- a/charts/v7.2/cray-hms-smd/templates/pvc.yaml
+++ b/charts/v7.2/cray-hms-smd/templates/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cray-smd-init-pvc
+spec:
+  accessModes:
+    - "{{ .Values.schemaAccessMode }}"
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: "{{ .Values.schemaStorageClass }}"

--- a/charts/v7.2/cray-hms-smd/templates/tests/check-hardware.yaml
+++ b/charts/v7.2/cray-hms-smd/templates/tests/check-hardware.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-check-hardware"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "2" #run this after smoke and functional
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-check-hardware"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-check-hardware"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-check-hardware"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "check-hardware"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh tavern -c /src/libs/tavern_global_config.yaml -p /src/app/api/1-hardware-checks"]

--- a/charts/v7.2/cray-hms-smd/templates/tests/test-functional.yaml
+++ b/charts/v7.2/cray-hms-smd/templates/tests/test-functional.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-functional"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "1" #run this after smoke!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-functional"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-functional"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-functional"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "functional"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh tavern -c /src/libs/tavern_global_config.yaml -p /src/app/api/2-non-disruptive"]

--- a/charts/v7.2/cray-hms-smd/templates/tests/test-smoke.yaml
+++ b/charts/v7.2/cray-hms-smd/templates/tests/test-smoke.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-smoke"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1" #run this first!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-smoke"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-smoke"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-smoke"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "smoke"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh smoke -f smoke.json -u http://cray-smd"]

--- a/charts/v7.2/cray-hms-smd/values.yaml
+++ b/charts/v7.2/cray-hms-smd/values.yaml
@@ -1,0 +1,186 @@
+# Please refer to https://github.com/Cray-HPE/cray-charts/tree/master/stable/cray-service/values.yaml?at=refs%2Fheads%2Fmaster
+# for more info on values you can set/override
+# Note that cray-service.containers[*].image and cray-service.initContainers[*].image map values are one of the only structures that
+# differ from the standard kubernetes container spec:
+# image:
+#   repository: ""
+#   tag: "" (default = "latest")
+#   pullPolicy: "" (default = "IfNotPresent")
+
+global:
+  appVersion: 2.33.0
+  testVersion: 2.33.0
+
+image:
+  repository: artifactory.algol60.net/csm-docker/stable/cray-smd
+  pullPolicy: IfNotPresent
+
+tests:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/cray-smd-hmth-test
+    pullPolicy: IfNotPresent
+
+kubectl:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
+    tag: 1.24.17
+    pullPolicy: IfNotPresent
+
+schemaStorageClass: ceph-cephfs-external
+schemaAccessMode: ReadWriteMany
+
+hms_ca_uri: ""
+
+smdInitJobTTL: 2147483647
+
+cray-service:
+  type: "Deployment"
+  nameOverride: "cray-smd"
+  fullnameOverride: "cray-smd"
+  replicaCount: 3
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - istio-ingressgateway
+                  - istio-ingressgateway-hmn
+            topologyKey: "kubernetes.io/hostname"
+            namespaces:
+              - istio-system
+  priorityClassName: "csm-high-priority-service"
+  containers:
+    cray-smd:
+      name: "cray-smd"
+      image:
+        repository: artifactory.algol60.net/csm-docker/stable/cray-smd
+      resources:
+        limits:
+          cpu: "16"
+          memory: 4Gi
+        requests:
+          cpu: "4"
+          memory: 256Mi
+      env:
+        # NOTE: overridden if POSTGRES_HOST is set
+        - name: SMD_DBHOST
+          value: cray-smd-postgres
+        # NOTE: overwritten if POSTGRES_PORT is set
+        - name: SMD_DBPORT
+          value: "5432"
+        - name: SMD_DBNAME
+          value: "hmsds"
+        - name: SMD_DBOPTS
+          value: ""
+        - name: SMD_DBUSER
+          valueFrom:
+            secretKeyRef:
+              name: hmsdsuser.cray-smd-postgres.credentials
+              key: username
+        - name: SMD_DBPASS
+          valueFrom:
+            secretKeyRef:
+              name: hmsdsuser.cray-smd-postgres.credentials
+              key: password
+        - name: RF_MSG_HOST
+          value: cray-shared-kafka-kafka-bootstrap.services.svc.cluster.local:9092:cray-dmtf-resource-event
+        - name: TLSCERT
+          value: ""
+        - name: TLSKEY
+          value: ""
+        - name: VAULT_ADDR
+          value: "http://cray-vault.vault:8200"
+        - name: VAULT_SKIP_VERIFY
+          value: "true"
+        - name: SMD_RVAULT
+          value: "true"
+        - name: SMD_WVAULT
+          value: "true"
+        - name: SMD_SLS_HOST
+          value: "http://cray-sls/v1"
+        - name: LOGLEVEL
+          value: "2"
+        - name: SMD_HWINVHIST_AGE_MAX_DAYS
+          value: "365"
+        - name: HMS_CONFIG_PATH
+          value: "/hms_config/hms_config.json"
+        - name: SMD_CA_URI
+          valueFrom:
+            configMapKeyRef:
+              name: smd-cacert-info
+              key: CA_URI
+        - name: SMD_HBTD_HOST
+          value: "http://cray-hbtd/hmi/v1"
+        - name: GOMAXPROCS
+          value: "8"
+        - name: POSTGRES_HOST
+          value: cray-smd-postgres
+        - name: POSTGRES_PORT
+          value: "5432"
+      ports:
+        - name: http
+          containerPort: 27779
+      livenessProbe:
+        httpGet:
+          port: 27779
+          path: /hsm/v2/service/liveness
+        initialDelaySeconds: 5
+        periodSeconds: 10
+      readinessProbe:
+        httpGet:
+          port: 27779
+          path: /hsm/v2/service/ready
+        initialDelaySeconds: 15
+        periodSeconds: 30
+        timeoutSeconds: 10
+      volumeMounts:
+        - name: hms-config-vol
+          mountPath: /hms_config/
+        - name: cray-pki-cacert-vol
+          mountPath: /usr/local/cray-pki
+  volumes:
+    hms-config-vol:
+      name: hms-config-vol
+      configMap:
+        name: cray-hms-base-config
+        optional: true
+    cray-pki-cacert-vol:
+      name: cray-pki-cacert-vol
+      configMap:
+        name: cray-configmap-ca-public-key
+        optional: true
+  ingress:
+    enabled: true
+    prefix: "/apis/smd/"
+    uri: "/"
+  podAnnotations:
+    traffic.sidecar.istio.io/excludeOutboundPorts: "8082,9092,2181"
+
+cray-postgresql:
+  nameOverride: "cray-smd"
+  fullnameOverride: "cray-smd"
+  sqlCluster:
+    enabled: true
+    enableLogicalBackup: true
+    logicalBackupSchedule: "10 0 * * *"  # Once per day at 12:10AM
+    instanceCount: 3
+    tls:
+      enabled: true
+    users:
+      hmsdsuser: []
+    databases:
+      hmsds: hmsdsuser
+    volumeSize: 100Gi
+    resources:
+      limits:
+        cpu: "32"
+        memory: 32Gi
+      requests:
+        cpu: "4"
+        memory: 8Gi
+    podPriorityClassName: "csm-high-priority-service"

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -6,7 +6,8 @@ chartVersionToCSMVersion:
   #   Chart Version: 2.1.0 <= x.y.z < 5.0.0, CSM Version: 1.3.0 <= x.y.z < 1.4.0
   #   Chart Version: 5.0.0 <= x.y.z < 6.0.0, CSM Version: 1.4.0 <= x.y.z < 1.5.0
   #   Chart Version: 6.0.0 <= x.y.z < 7.1.0, CSM Version: 1.5.0 <= x.y.z < 1.6.0
-  #   Chart Version: 7.1.0 <= x.y.z,         CSM Version: 1.6.0 <= x.y.z
+  #   Chart Version: 7.1.0 <= x.y.z < 7.2.0, CSM Version: 1.6.0 <= x.y.z < 1.7.0
+  #   Chart Version: 7.2.0 <= x.y.z,         CSM Version: 1.7.0 <= x.y.z
   #
   # Chart version: CSM version
   ">=2.0.0": "~1.2.0"
@@ -100,6 +101,7 @@ chartVersionToApplicationVersion:
   "7.1.18": "2.29.0"
   "7.1.19": "2.30.0"
   "7.1.20": "2.31.0"
+  "7.2.0": "2.33.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated image and module dependencies for security updates.

Fixed a bunch of pre-existing build warnings in Dockerfiles as it was difficult to look for possible new warnings/errors associated with the image and module updates.

Added image-pprof Makefile support as the above module updates fixed the back-end ARM build issue associated with not being able to enable it previously.

The tavern tests were updated to look for a returned 404 http code rather than a 405 code due to the gorilla/mux change https://github.com/gorilla/mux/pull/712 that came with updating the gorilla module.

Updates to hms-certs, hms-compcredentials, and hms-securestorage were not included.  A new Jira will be created to handle them seperately.  This is because updating these modules will require functional changes surrounding vault use due to the changes associated with CASMHMS-5445.

Adopted app version 2.33.0 for CSM 1.6.1 (helm chart 7.2.0)

### Issues and Related PRs

* Resolves [CASMHMS-5678](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-5678)

### Testing

Ran PCS smoke and integration tests on mug.

Tested on:

* `mug`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable

### High level diff of changes

```
$ diff -r charts/v7.1/ charts/v7.2/
diff -r charts/v7.1/cray-hms-smd/Chart.yaml charts/v7.2/cray-hms-smd/Chart.yaml
3c3
< version: 7.1.20
---
> version: 7.2.0
18c18
< appVersion: "2.31.0"  # update pprof image version below as well
---
> appVersion: "2.33.0"  # update pprof image version below as well
22c22
<       image: artifactory.algol60.net/csm-docker/stable/cray-smd-pprof:2.31.0
---
>       image: artifactory.algol60.net/csm-docker/stable/cray-smd-pprof:2.33.0
diff -r charts/v7.1/cray-hms-smd/values.yaml charts/v7.2/cray-hms-smd/values.yaml
11,12c11,12
<   appVersion: 2.31.0
<   testVersion: 2.31.0
---
>   appVersion: 2.33.0
>   testVersion: 2.33.0
```