### PR TITLE
CASMHMS-5678: Update module dependencies related to vault and hms-certs

### DIFF
--- a/changelog/v7.2.md
+++ b/changelog/v7.2.md
@@ -5,6 +5,12 @@ All notable changes to this project for v7.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.2.1] - 2025-01-24
+
+### Security
+
+- Update module dependencies related to hms-certs
+
 ## [7.2.0] - 2025-01-24
 
 ### Security

--- a/charts/v7.2/cray-hms-smd/Chart.yaml
+++ b/charts/v7.2/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.2.0
+version: 7.2.1
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,9 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.33.0"  # update pprof image version below as well
+appVersion: "2.34.0"  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-smd-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-smd-pprof:2.33.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-smd-pprof:2.34.0
   artifacthub.io/license: "MIT"

--- a/charts/v7.2/cray-hms-smd/values.yaml
+++ b/charts/v7.2/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.33.0
-  testVersion: 2.33.0
+  appVersion: 2.34.0
+  testVersion: 2.34.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -104,6 +104,7 @@ chartVersionToApplicationVersion:
   "7.1.20": "2.31.0"
   "7.1.21": "2.32.0"
   "7.2.0": "2.33.0"
+  "7.2.1": "2.34.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated module dependencies for security updates.

The hms-certs update required changes to pass vault related override values to hms-certs.

Adopted app version 2.34.0 for CSM 1.7.0 (helm chart 7.2.1)

### Issues and Related PRs

* Resolves [CASMHMS-5678](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-5678)

### Testing

Ran smoke and integration tests.

Tested on:

* `mug`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable