### PR TITLE
CASMHMS-6482: Update modules to pull in fixes to resource issues in HMS modules

### DIFF
--- a/changelog/v7.2.md
+++ b/changelog/v7.2.md
@@ -5,6 +5,15 @@ All notable changes to this project for v7.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.2.4] - 2025-04-17
+
+## Update
+
+- Updated module and image dependencies to latest versions
+- Removed some code that's now redundant with new hms-base module
+- Update version of Go to v1.24
+- Internal tracking tickets: CASMHMS-6482, CASMHMS-6401, CASMHMS-6402
+
 ## [7.2.3] - 2025-04-14
 
 ## Fixed

--- a/changelog/v7.2.md
+++ b/changelog/v7.2.md
@@ -5,7 +5,7 @@ All notable changes to this project for v7.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.2.4] - 2025-04-17
+## [7.2.4] - 2025-04-18
 
 ## Update
 

--- a/changelog/v7.2.md
+++ b/changelog/v7.2.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Update
 
 - Updated module and image dependencies to latest versions
-- Removed some code that's now redundant with new hms-base module
 - Update version of Go to v1.24
+- Removed several sections of code code that's now redundant with the
+  latest hms-base module
+- Fixed various issues associated with upgrading Go to v1.24
 - Internal tracking tickets: CASMHMS-6482, CASMHMS-6401, CASMHMS-6402
 
 ## [7.2.3] - 2025-04-14

--- a/charts/v7.2/cray-hms-smd/Chart.yaml
+++ b/charts/v7.2/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.2.3
+version: 7.2.4
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,9 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.36.0"  # update pprof image version below as well
+appVersion: "2.37.0"  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-smd-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-smd-pprof:2.36.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-smd-pprof:2.37.0
   artifacthub.io/license: "MIT"

--- a/charts/v7.2/cray-hms-smd/values.yaml
+++ b/charts/v7.2/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.36.0
-  testVersion: 2.36.0
+  appVersion: 2.37.0
+  testVersion: 2.37.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -108,6 +108,7 @@ chartVersionToApplicationVersion:
   "7.2.1": "2.34.0"
   "7.2.2": "2.35.0"
   "7.2.3": "2.36.0"
+  "7.2.4": "2.37.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated all module and image dependencies to latest versions.  The primary reason for this was to pick up some resource leak fixes to the hms-base, hms-certs, and hms-go-http-lib modules.  Several sections of SMD code were removed and/or replaced due to the most recent changes to hms-base.

Additionally upgraded Go from v1.23 to v1.24.  There were a number of SMD code changes that were required to support differences in these two version of Go.

Adopted app version 2.37.0 for CSM 1.7.0 (helm chart 7.2.4).

### Issues and Related PRs

* Resolves [CASMHMS-6482](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6482)

### Testing

Tested on:

* `mug`

Test description:

Upgraded to dev version of SMD.  Watched log files to ensure nothing obvious was wrong.  Ran the standard SMD smoke and functional tests which all passed.  Ran xtdiscover against several BMCs to ensure no issues with that functionality.

Watched RTS logs to ensure no deviations from running without these changes.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable