### PR TITLE
CASMHMS-6499: Added 'curl' command to container image and fix CT test

### DIFF
--- a/changelog/v7.2.md
+++ b/changelog/v7.2.md
@@ -5,11 +5,12 @@ All notable changes to this project for v7.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.2.5] - 2025-05-01
+## [7.2.5] - 2025-04-30
 
 ### Update
 
 - Added 'curl' command to container image
+- Remove potential for future false positives in CT test
 - Internal tracking ticket: CASMHMS-6499
 
 ## [7.2.4] - 2025-04-18

--- a/changelog/v7.2.md
+++ b/changelog/v7.2.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added 'curl' command to container image
 - Remove potential for future false positives in CT test
-- Internal tracking ticket: CASMHMS-6499
+- Internal tracking tickets: CASMHMS-6499, CASMTRIAGE-8079
 
 ## [7.2.4] - 2025-04-18
 

--- a/changelog/v7.2.md
+++ b/changelog/v7.2.md
@@ -5,6 +5,13 @@ All notable changes to this project for v7.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.2.5] - 2025-05-01
+
+### Update
+
+- Added 'curl' command to container image
+- Internal tracking ticket: CASMHMS-6499
+
 ## [7.2.4] - 2025-04-18
 
 ## Update

--- a/charts/v7.2/cray-hms-smd/Chart.yaml
+++ b/charts/v7.2/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.2.4
+version: 7.2.5
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,9 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.37.0"  # update pprof image version below as well
+appVersion: "2.38.0"  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-smd-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-smd-pprof:2.37.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-smd-pprof:2.38.0
   artifacthub.io/license: "MIT"

--- a/charts/v7.2/cray-hms-smd/values.yaml
+++ b/charts/v7.2/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.37.0
-  testVersion: 2.37.0
+  appVersion: 2.38.0
+  testVersion: 2.38.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -109,6 +109,7 @@ chartVersionToApplicationVersion:
   "7.2.2": "2.35.0"
   "7.2.3": "2.36.0"
   "7.2.4": "2.37.0"
+  "7.2.5": "2.38.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Added 'curl' command to container image and removed all future potential for false positive failures in the CT tests associated with ethernet device naming.

Adopted app version 2.38.0 for CSM 1.7.0 (helm chart 7.2.5).

## Issues and Related PRs

* Resolves [CASMHMS-6499](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6499)
* Resolves [CASMTRIAGE-8079](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8079)

## Testing

Tested on:

  * Local development environment
  * mug

Test description:

Loaded image into Docker Desktop on laptop and verified 'curl' command was present.  No further testing necessary.

Loaded onto mug and ran CT tests to verify tests still pass.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable