### PR TITLE
CASMHMS-6516: Bump postgresql and cray-service to latest versions

### DIFF
--- a/changelog/v7.2.md
+++ b/changelog/v7.2.md
@@ -5,11 +5,12 @@ All notable changes to this project for v7.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.2.6] - 2025-05-13
+## [7.2.6] - 2025-05-14
 
 ### Updated
 
 - Updated cray-postgresql and cray-service dependencies to the latest versions
+- Internal tracking ticket: CASMHMS-6516
 
 ## [7.2.5] - 2025-04-30
 

--- a/changelog/v7.2.md
+++ b/changelog/v7.2.md
@@ -5,6 +5,12 @@ All notable changes to this project for v7.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.2.6] - 2025-05-13
+
+### Updated
+
+- Updated cray-postgresql and cray-service dependencies to the latest versions
+
 ## [7.2.5] - 2025-04-30
 
 ### Update

--- a/charts/v7.2/cray-hms-smd/Chart.yaml
+++ b/charts/v7.2/cray-hms-smd/Chart.yaml
@@ -1,16 +1,16 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.2.5
+version: 7.2.6
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
   - "https://github.com/Cray-HPE/hms-smd"
 dependencies:
   - name: cray-service
-    version: "~11.0"
+    version: "~12.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
   - name: cray-postgresql
-    version: "~1.0"
+    version: "~2.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 maintainers:
   - name: Hardware Management

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -110,6 +110,7 @@ chartVersionToApplicationVersion:
   "7.2.3": "2.36.0"
   "7.2.4": "2.37.0"
   "7.2.5": "2.38.0"
+  "7.2.6": "2.38.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated cray-postgresql and cray-service dependencies to the latest versions

New helm chart version is 7.2.6 (no app version change)

### Issues and Related PRs

* Resolves [CASMHMS-6516](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6516)

### Testing

Tested on:

* `beau` (vshasta)

Test description:

- Helm upgrade of the new chart
   - Had to do a 'rollout restart' to restart the pods since the container image didn't change
- Ran HMS CT tests
- Verified wait-for-postgres pod ran and functioned correctly
- Helm rollback to the prior version of the service

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable