### PR TITLE
CASMHMS-6596: Use new hms-test image with fix for missing distutils d…

### DIFF
--- a/changelog/v7.2.md
+++ b/changelog/v7.2.md
@@ -5,6 +5,13 @@ All notable changes to this project for v7.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.2.9] - 2025-09-08
+
+### Fixed
+
+- Use new hms-test image with fix for missing distutils dependency
+- Internal tracking ticket: CASMHMS-6596
+
 ## [7.2.8] - 2025-07-31
 
 ### Fixed

--- a/charts/v7.2/cray-hms-smd/Chart.yaml
+++ b/charts/v7.2/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.2.8
+version: 7.2.9
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,9 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.40.0"  # update pprof image version below as well
+appVersion: "2.41.0"  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-smd-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-smd-pprof:2.40.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-smd-pprof:2.41.0
   artifacthub.io/license: "MIT"

--- a/charts/v7.2/cray-hms-smd/values.yaml
+++ b/charts/v7.2/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.40.0
-  testVersion: 2.40.0
+  appVersion: 2.41.0
+  testVersion: 2.41.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -116,6 +116,7 @@ chartVersionToApplicationVersion:
   "7.2.6": "2.38.0"
   "7.2.7": "2.39.0"
   "7.2.8": "2.40.0"
+  "7.2.9": "2.41.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Use new hms-test image with fix for missing distutils dependency.  Without this, CT execution with newer builds were failing because setuptools disappeared from the environment.

Adopted app version 2.41.0 for CSM 1.7.1 (helm chart 7.2.9)

### Issues and Related PRs

* Resolves [CASMHMS-6596](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6596)

### Testing

Tested via pipeline execution of CT tests.  Dev branch failed without the changes.  Once changes pushed up, dev branch started passing CT tests.  No need to test on a real system.

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable