### PR TITLE
CASMHMS-6586: Fixed float vs integer bug in hardware tavern test

### DIFF
--- a/changelog/v7.1.md
+++ b/changelog/v7.1.md
@@ -5,6 +5,13 @@ All notable changes to this project for v7.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.26] - 2025-09-16
+
+### Fixed
+
+- Fixed float vs integer bug in hardware tavern test
+- Internal tracking ticket: CASMHMS-6586
+
 ## [7.1.25] - 2025-08-20
 
 ### Updated

--- a/changelog/v7.2.md
+++ b/changelog/v7.2.md
@@ -5,6 +5,13 @@ All notable changes to this project for v7.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.2.10] - 2025-09-16
+
+### Fixed
+
+- Fixed float vs integer bug in hardware tavern test
+- Internal tracking ticket: CASMHMS-6586
+
 ## [7.2.9] - 2025-09-10
 
 ### Fixed

--- a/charts/v7.1/cray-hms-smd/Chart.yaml
+++ b/charts/v7.1/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.1.25
+version: 7.1.26
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,9 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.32.6"  # update pprof image version below as well
+appVersion: "2.32.7"  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-smd-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-smd-pprof:2.32.6
+      image: artifactory.algol60.net/csm-docker/stable/cray-smd-pprof:2.32.7
   artifacthub.io/license: "MIT"

--- a/charts/v7.1/cray-hms-smd/values.yaml
+++ b/charts/v7.1/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.32.6
-  testVersion: 2.32.6
+  appVersion: 2.32.7
+  testVersion: 2.32.7
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/charts/v7.2/cray-hms-smd/Chart.yaml
+++ b/charts/v7.2/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.2.9
+version: 7.2.10
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,9 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.41.0"  # update pprof image version below as well
+appVersion: "2.42.0"  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-smd-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-smd-pprof:2.41.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-smd-pprof:2.42.0
   artifacthub.io/license: "MIT"

--- a/charts/v7.2/cray-hms-smd/values.yaml
+++ b/charts/v7.2/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.41.0
-  testVersion: 2.41.0
+  appVersion: 2.42.0
+  testVersion: 2.42.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -107,6 +107,7 @@ chartVersionToApplicationVersion:
   "7.1.23": "2.32.2"
   "7.1.24": "2.32.5"	# 3.32.5 needed due to 2.32.3 and 2.32.4 tagging issues
   "7.1.25": "2.32.6"
+  "7.1.26": "2.32.7"
   "7.2.0": "2.33.0"
   "7.2.1": "2.34.0"
   "7.2.2": "2.35.0"
@@ -117,6 +118,7 @@ chartVersionToApplicationVersion:
   "7.2.7": "2.39.0"
   "7.2.8": "2.40.0"
   "7.2.9": "2.41.0"
+  "7.2.10": "2.42.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Unsure if its a result of a new BMC fw version, or a particular new kind of SSD device, but the values returned from the following redfish endpoint now sometimes return floating point values rather than integer values on DL River hardware:

```bash
/redfish/v1/Systems/1/Storage/${DEVICE_NAME}/Drives/${DRIVE_NUMBER}
```

This was causing one of the SMD CT tests to fail.  The fix here is to accept either integer or floating point values in the test.

Adopted app version 2.32.7 for CSM 1.6.3 (helm chart 7.1.26)
Adopted app version 2.42.0 for CSM 1.7.1 (helm chart 7.2.10)

### Issues and Related PRs

* Resolves [CASMHMS-6586](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6586)

### Testing

Fudged required redfish endpoints with floating point data from the failing customer system into the DL325 mockup folder in `csm-redfish-interface-emulator` and then updated SMD's `docker-compose.test.ct.yaml` to use only the DL325 mockup for all four RIE emulators.  Ran the CT tests locally on my laptop and observed the failure.  Applied the fix to SMD and reran the CT tests locally on my laptop and observed that the tests no longer failed.

Will not check in the `csm-redfish-interface-emulator` changes as we need to keep the EX235a emulators in SMD's CT test environment.  No point in adding a fifth emulator for DL325 because the CT test randomly selects nodes to test again, and it would be unlikely that the DL325 node would be selected.

CT tests pass in the build pipeline.

Did no harm CT test run on the CSM 1.6.2 system `baldar`.

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable