### PR TITLE
CASMHMS-6600: Add new FMN roles/subroles

### DIFF
--- a/changelog/v7.2.md
+++ b/changelog/v7.2.md
@@ -5,6 +5,11 @@ All notable changes to this project for v7.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.2.11] - 2025-09-26
+
+- Added new FMN roles/subroles (TBD MESSAGING)
+- Internal tracking ticket: CASMHMS-6600
+
 ## [7.2.10] - 2025-09-16
 
 ### Fixed

--- a/charts/v7.2/cray-hms-smd/Chart.yaml
+++ b/charts/v7.2/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.2.10
+version: 7.2.11
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:

--- a/charts/v7.2/cray-hms-smd/templates/configmap.yaml
+++ b/charts/v7.2/cray-hms-smd/templates/configmap.yaml
@@ -9,7 +9,8 @@ data:
              "System",
              "Application",
              "Storage",
-             "Management"
+             "Management",
+             "SSFabricManagerRole"
           ],
           "SubRole":[
              "Worker",
@@ -19,7 +20,8 @@ data:
              "Gateway",
              "LNETRouter",
              "Visualization",
-             "UserDefined"
+             "UserDefined",
+             "SSFabricManagerSubrole"
           ]
        }
     }

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -119,6 +119,7 @@ chartVersionToApplicationVersion:
   "7.2.8": "2.40.0"
   "7.2.9": "2.41.0"
   "7.2.10": "2.42.0"
+  "7.2.11": "2.42.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Define new roles in HSM's `cray-hms-base-config` configmap for the new Slingshot Fabric Manager Nodes (FMN).

Adopted helm chart version 7.2.11 for CSM 1.7.1 (no change in app version)

### Issues and Related PRs

* Resolves [CASMHMS-6600](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6600)

### Testing

Tested on `mug`.  Upgraded to modified helm chart.  Observed change in the configmap.  Created a new fake component in HSM and assigned the new role and subrole.  Observed their presence in `sat` and `hsm` output

```
> sat status | grep -e xname -e SSFabric
| xname          | Aliases   | Type | NID      | State     | Flag | Enabled | Arch | Class | Role                | SubRole                | Net Type | Locked  | Desired Config                         | Configuration Status | Error Count | Boot Status | Most Recent BOS Session                | Most Recent Session Template           | Most Recent Image                    |
| x3100c0s0b0n0  | MISSING   | Node | 123456   | On        | OK   | True    | X86  | River | SSFabricManagerRole | SSFabricManagerSubrole | Sling    | MISSING |                                        | unconfigured         | 0           | MISSING     | MISSING                                | MISSING                                | MISSING                              |

> cray hsm state components list --role SSFabricManagerRole | jq .Components[].ID
"x3100c0s0b0n0"

> cray hsm state components list --subrole SSFabricManagerSubRole | jq .Components[].ID
"x3100c0s0b0n0"
```

Then created new custom `TestRole` role and `TestSubrole` subrole using https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/hardware_state_manager/HSM_Roles_and_Subroles.md and verified correct behavior and coexistance with new role/subrole in the configmap and by modifying the adove fake component.

Confirmed CT tests still pass.

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable