### PR TITLE
CASMHMS-6551: Update misc SMD dependencies for CSM 1.7.1

### DIFF
--- a/changelog/v7.2.md
+++ b/changelog/v7.2.md
@@ -5,6 +5,14 @@ All notable changes to this project for v7.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.2.11] - 2025-09-18
+
+### Security
+
+- Updated Alpine base image to pick up security fixes
+- Updated CT test image version dependencies
+- Internal tracking ticket: CASMHMS-6551
+
 ## [7.2.10] - 2025-09-16
 
 ### Fixed

--- a/changelog/v7.2.md
+++ b/changelog/v7.2.md
@@ -5,12 +5,13 @@ All notable changes to this project for v7.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.2.11] - 2025-09-18
+## [7.2.11] - 2025-09-19
 
 ### Security
 
 - Updated Alpine base image to pick up security fixes
 - Updated CT test image version dependencies
+- Updated HMS Go module dependencies
 - Internal tracking ticket: CASMHMS-6551
 
 ## [7.2.10] - 2025-09-16

--- a/charts/v7.2/cray-hms-smd/Chart.yaml
+++ b/charts/v7.2/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.2.10
+version: 7.2.11
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,9 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.42.0"  # update pprof image version below as well
+appVersion: "2.43.0"  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-smd-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-smd-pprof:2.42.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-smd-pprof:2.43.0
   artifacthub.io/license: "MIT"

--- a/charts/v7.2/cray-hms-smd/values.yaml
+++ b/charts/v7.2/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.42.0
-  testVersion: 2.42.0
+  appVersion: 2.43.0
+  testVersion: 2.43.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -119,6 +119,7 @@ chartVersionToApplicationVersion:
   "7.2.8": "2.40.0"
   "7.2.9": "2.41.0"
   "7.2.10": "2.42.0"
+  "7.2.11": "2.43.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated Alpine base image from 3.21 to 3.22 to pick up security fixes.

Updated CT test image version dependencies so that the test infractructure is always references the latest versions of HMS services.

Also updated the Go module dependencies for HMS libraries and services.

Adopted app version 2.43.0 for CSM 1.7.1 (helm chart 7.2.11)

### Issues and Related PRs

* Resolves [CASMHMS-6551](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6551)

### Testing

Tested via pipeline execution of CT tests and on system mug.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable