### PR TITLE
CASMTRIAGE-8890: Return empty list when no components match lock filter for GET requests

### DIFF
--- a/changelog/v7.2.md
+++ b/changelog/v7.2.md
@@ -5,7 +5,7 @@ All notable changes to this project for v7.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.2.14] - 2025-11-19
+## [7.2.14] - 2025-11-18
 
 ### Fixed
 

--- a/changelog/v7.2.md
+++ b/changelog/v7.2.md
@@ -5,6 +5,14 @@ All notable changes to this project for v7.2.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.2.14] - 2025-11-19
+
+### Fixed
+
+- Return empty list when no components match lock filter for GET requests
+- Update unit and CT tests with change
+- Internal tracking ticket: CASMTRIAGE-8890
+
 ## [7.2.13] - 2025-11-04
 
 ### Fixed

--- a/charts/v7.2/cray-hms-smd/Chart.yaml
+++ b/charts/v7.2/cray-hms-smd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-smd"
-version: 7.2.13
+version: 7.2.14
 description: "Kubernetes resources for cray-hms-smd"
 home: "https://github.com/Cray-HPE/hms-smd-charts"
 sources:
@@ -15,9 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.44.0"  # update pprof image version below as well
+appVersion: "2.45.0"  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-smd-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-smd-pprof:2.44.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-smd-pprof:2.45.0
   artifacthub.io/license: "MIT"

--- a/charts/v7.2/cray-hms-smd/values.yaml
+++ b/charts/v7.2/cray-hms-smd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.44.0
-  testVersion: 2.44.0
+  appVersion: 2.45.0
+  testVersion: 2.45.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-smd

--- a/cray-hms-smd.compatibility.yaml
+++ b/cray-hms-smd.compatibility.yaml
@@ -123,6 +123,7 @@ chartVersionToApplicationVersion:
   "7.2.11": "2.43.0"
   "7.2.12": "2.43.0"
   "7.2.13": "2.44.0"
+  "7.2.14": "2.45.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Previously, if a GET on the lock status API turned up no matching components, an HTTP 400 error was returned.  This is not correct behaviour, an empty list should be returned in this case.

The unit and CT tests had to be updated for this change.

Made some additional correctness changes in GetCompLocksV2() so that no result is returned, if an error is returned.

Adopted app version 2.45.0 for CSM 1.7.1 (helm chart 7.2.14)

## Issues and Related PRs

* Resolves [CASMTRIAGE-8890](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8890)

## Testing

Tested on:

  * `mug`

Test description:

Ran following test without change:

```
> cray hsm locks status list --type MgmtSwitch --locked True
Usage: cray hsm locks status list [OPTIONS]
Try 'cray hsm locks status list -h' for help.

Error: Bad Request: Component not found
```

Re-ran with my fix in place:

```
> cray hsm locks status list --type MgmtSwitch --locked True
{
  "Components": []
}
```

Manually ran other various other lock status requests to verify correct functionality remains in place.

Ran the SMD CT tests to verify no regressions.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable